### PR TITLE
Add a number of UI improvements to package release tool

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.{php,xml}]
+indent_size = 4
+
+[*.{diff,md}]
+trim_trailing_whitespace = false
+
+[Jenkinsfile]
+indent_size = 4

--- a/README.md
+++ b/README.md
@@ -11,11 +11,15 @@ Options:
                                  specified, "master" is used.
   -m message, --message=message  Message to use for the release tag.
   -t type, --type=type           Release type. Must be one of "major",
-                                 "minor", or "micro". If not specified,
-                                 "minor" is used.
+                                 "minor", or "patch". If not specified,
+                                 "minor" is used. Semver 2.0
+                                 (https://semver.org/) is used to pick the
+                                 next release number.
   -v, --verbose                  Sets verbosity level. Use multiples for
                                  more detail (e.g. "-vv").
   -q, --quiet                    Turn off all output.
+  -y, --yes                      Non-interactive mode. Assume yes for
+                                 prompts.
   -h, --help                     show this help message and exit
   --version                      show the program version and exit
 </pre>

--- a/bin/package-release
+++ b/bin/package-release
@@ -57,6 +57,7 @@ $logger->pushProcessor(new PsrLogMessageProcessor());
 $logger->pushHandler($verbosity_handler);
 
 $manager = new PackageRelease\Manager();
+$prompt = new PackageRelease\Prompt($logger);
 
 $parser = \Console_CommandLine::fromXmlFile(__DIR__ . '/../data/cli.xml');
 
@@ -64,7 +65,8 @@ $cli = new PackageRelease\CLI(
     $parser,
     $manager,
     $verbosity_handler,
-    $logger
+    $logger,
+    $prompt
 );
 
 $cli->run();

--- a/data/cli.xml
+++ b/data/cli.xml
@@ -22,9 +22,10 @@
 			<choice>major</choice>
 			<choice>minor</choice>
 			<choice>micro</choice>
+			<choice>patch</choice>
 		</choices>
 		<default>minor</default>
-		<description>Release type. Must be one of "major", "minor", or "micro". If not specified, "minor" is used.</description>
+		<description>Release type. Must be one of "major", "minor", or "patch". If not specified, "minor" is used. Semver 2.0 (https://semver.org/) is used to pick the next release number.</description>
 		<action>StoreString</action>
 	</option>
 	<option name="verbose">

--- a/data/cli.xml
+++ b/data/cli.xml
@@ -1,49 +1,49 @@
 <?xml version="1.0" encoding="iso-8859-1" standalone="yes"?>
 <command>
-	<description>Command-line tool to release new versions of composer packages.</description>
-	<version>1.0.0</version>
-	<option name="branch">
-		<short_name>-b</short_name>
-		<long_name>--branch</long_name>
-		<default>master</default>
-		<description>Remote branch to use for release. If not specified, "master" is used.</description>
-		<action>StoreString</action>
-	</option>
-	<option name="message">
-		<short_name>-m</short_name>
-		<long_name>--message</long_name>
-		<description>Message to use for the release tag.</description>
-		<action>StoreString</action>
-	</option>
-	<option name="type">
-		<short_name>-t</short_name>
-		<long_name>--type</long_name>
-		<choices>
-			<choice>major</choice>
-			<choice>minor</choice>
-			<choice>micro</choice>
-			<choice>patch</choice>
-		</choices>
-		<default>minor</default>
-		<description>Release type. Must be one of "major", "minor", or "patch". If not specified, "minor" is used. Semver 2.0 (https://semver.org/) is used to pick the next release number.</description>
-		<action>StoreString</action>
-	</option>
-	<option name="verbose">
-		<short_name>-v</short_name>
-		<long_name>--verbose</long_name>
-		<description>Sets verbosity level. Use multiples for more detail (e.g. "-vv").</description>
-		<action>Counter</action>
-	</option>
-	<option name="quiet">
-		<short_name>-q</short_name>
-		<long_name>--quiet</long_name>
-		<description>Turn off all output.</description>
-		<action>StoreTrue</action>
-	</option>
-	<option name="yes">
-		<short_name>-y</short_name>
-		<long_name>--yes</long_name>
-		<description>Non-interactive mode. Assume yes for prompts.</description>
-		<action>StoreTrue</action>
-	</option>
+    <description>Command-line tool to release new versions of composer packages.</description>
+    <version>1.0.0</version>
+    <option name="branch">
+        <short_name>-b</short_name>
+        <long_name>--branch</long_name>
+        <default>master</default>
+        <description>Remote branch to use for release. If not specified, "master" is used.</description>
+        <action>StoreString</action>
+    </option>
+    <option name="message">
+        <short_name>-m</short_name>
+        <long_name>--message</long_name>
+        <description>Message to use for the release tag.</description>
+        <action>StoreString</action>
+    </option>
+    <option name="type">
+        <short_name>-t</short_name>
+        <long_name>--type</long_name>
+        <choices>
+            <choice>major</choice>
+            <choice>minor</choice>
+            <choice>micro</choice>
+            <choice>patch</choice>
+        </choices>
+        <default>minor</default>
+        <description>Release type. Must be one of "major", "minor", or "patch". If not specified, "minor" is used. Semver 2.0 (https://semver.org/) is used to pick the next release number.</description>
+        <action>StoreString</action>
+    </option>
+    <option name="verbose">
+        <short_name>-v</short_name>
+        <long_name>--verbose</long_name>
+        <description>Sets verbosity level. Use multiples for more detail (e.g. "-vv").</description>
+        <action>Counter</action>
+    </option>
+    <option name="quiet">
+        <short_name>-q</short_name>
+        <long_name>--quiet</long_name>
+        <description>Turn off all output.</description>
+        <action>StoreTrue</action>
+    </option>
+    <option name="yes">
+        <short_name>-y</short_name>
+        <long_name>--yes</long_name>
+        <description>Non-interactive mode. Assume yes for prompts.</description>
+        <action>StoreTrue</action>
+    </option>
 </command>

--- a/data/cli.xml
+++ b/data/cli.xml
@@ -40,4 +40,10 @@
 		<description>Turn off all output.</description>
 		<action>StoreTrue</action>
 	</option>
+	<option name="yes">
+		<short_name>-y</short_name>
+		<long_name>--yes</long_name>
+		<description>Non-interactive mode. Assume yes for prompts.</description>
+		<action>StoreTrue</action>
+	</option>
 </command>

--- a/data/cli.xml
+++ b/data/cli.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1" standalone="yes"?>
 <command>
 	<description>Command-line tool to release new versions of composer packages.</description>
-	<version>0.1.0</version>
+	<version>1.0.0</version>
 	<option name="branch">
 		<short_name>-b</short_name>
 		<long_name>--branch</long_name>

--- a/src/CLI.php
+++ b/src/CLI.php
@@ -91,7 +91,7 @@ class CLI implements Log\LoggerAwareInterface
                 );
             } else {
                 $this->verbosity_handler->setVerbosity(
-                    $result->options['verbose'] + 1
+                    $result->options['verbose'] + VerbosityHandler::VERBOSITY_VERBOSE
                 );
             }
 

--- a/src/CLI.php
+++ b/src/CLI.php
@@ -153,7 +153,7 @@ class CLI implements Log\LoggerAwareInterface
             if (!$result->options['yes']) {
                 $continue = $this->prompt->ask(
                     sprintf(
-                        'Ready to release new %s version %s. Continue? (Y/N)',
+                        'Ready to release new %s version %s. Continue? [Y/N]',
                         $result->options['type'],
                         $next_version
                     ),

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -14,7 +14,8 @@ class Manager
 {
     const VERSION_MAJOR = 'major';
     const VERSION_MINOR = 'minor';
-    const VERSION_MICRO = 'micro';
+    const VERSION_PATCH = 'patch';
+    const VERSION_MICRO = 'micro'; // deprecated alias for VERSION_PATCH
 
     /**
      * Checks if the current directory is a git repository
@@ -297,7 +298,7 @@ class Manager
      *                                 one of
      *                                 {@link PackageRelease::VERSION_MAJOR},
      *                                 {@link PackageRelease::VERSION_MINOR}, or
-     *                                 {@link PackageRelease::VERSION_MICRO}. If
+     *                                 {@link PackageRelease::VERSION_PATCH}. If
      *                                 not specified, a minor release is
      *                                 used.
      *
@@ -316,6 +317,7 @@ class Manager
                 case self::VERSION_MAJOR:
                     $next = ($parts[0] + 1) . '.0.0';
                     break;
+                case self::VERSION_PATCH:
                 case self::VERSION_MICRO:
                     $next = $parts[0] . '.' . $parts[1] . '.' . ($parts[2] + 1);
                     break;

--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -25,19 +25,25 @@ class Prompt
     /**
      * Asks a yes or no question, waits for a response and returns a boolean
      *
-     * @param string $prompt optional. The prompt text to use.
+     * @param string $line1 optional. The prompt text to use. If $line2 is
+     *                      specified, this is displayed above the input line.
+     *                      If not specified, 'Yes or no? ' is used.
+     * @param string $line2 optional. The prompt text to use. $line1 is
+     *                      displayed above the input and this line is displayed
+     *                      before the input. If not specified, $line1 is
+     *                      displayed before the input.
      *
      * @return boolean true if the user entered yes, otherwise false.
      */
-    public function ask($line1 = 'Yes or no? ', $line2 = '')
+    public function ask($line1 = 'Yes or no? ', $line2 = null)
     {
         $answered = false;
 
-        $prompt = ($line2 == '') ? $line1 : $line2;
+        $prompt = ($line2 === null) ? $line1 : $line2;
         $this->logger->notice('');
 
         while (!$answered) {
-            if ($line2 != '') {
+            if ($line2 !== null) {
                 $this->logger->notice($line1);
             }
             $response = readline($prompt);

--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace silverorange\PackageRelease;
+
+use Psr\Log;
+
+/**
+ * @package   PackageRelease
+ * @author    Michael Gauthier <mike@silverorange.com>
+ * @copyright 2017 silverorange
+ * @license   http://www.opensource.org/licenses/mit-license.html MIT License
+ */
+class Prompt
+{
+    /**
+     * @var Log\LoggerInterface $logger
+     */
+    protected $logger = null;
+
+    public function __construct(Log\LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * Asks a yes or no question, waits for a response and returns a boolean
+     *
+     * @param string $prompt optional. The prompt text to use.
+     *
+     * @return boolean true if the user entered yes, otherwise false.
+     */
+    public function ask($line1 = 'Yes or no? ', $line2 = '')
+    {
+        $answered = false;
+
+        $prompt = ($line2 == '') ? $line1 : $line2;
+        $this->logger->notice('');
+
+        while (!$answered) {
+            if ($line2 != '') {
+                $this->logger->notice($line1);
+            }
+            $response = readline($prompt);
+            if (preg_match('/^y|yes$/i', $response) === 1) {
+                $response = true;
+                $answered = true;
+            } elseif (preg_match('/^n|no$/i', $response) === 1) {
+                $response = false;
+                $answered = true;
+            }
+            $this->logger->notice('');
+        }
+
+        return $response;
+    }
+}

--- a/src/VerbosityHandler.php
+++ b/src/VerbosityHandler.php
@@ -57,7 +57,7 @@ class VerbosityHandler extends HandlerWrapper
      */
     public function setVerbosity($verbosity)
     {
-        $this->verbosity = (integer)$verbosity;
+        $this->verbosity = min((integer)$verbosity, self::VERBOSITY_DEBUG);
     }
 
     /**


### PR DESCRIPTION
The goal of these changes is to make accidental minor releases that should be patch releases more difficult.

 - show output by default. Use more `-v` for debug level output. Use `-q` if you want no output.
 - prompt to continue release. Use `-y` to skip prompt.
 - update docs and CLI to use `patch` as the third version number instead of `micro`.