### PR TITLE
Beautify the user-interface

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,41 @@
+pipeline {
+    agent any
+    stages {
+        stage('Install Composer Dependencies') {
+            steps {
+                sh 'rm -rf composer.lock vendor/'
+                sh 'composer install'
+            }
+        }
+
+        stage('Lint Modified Files') {
+            when {
+                not {
+                    branch 'master'
+                }
+            }
+            steps {
+                sh '''
+                    master_sha=$(git rev-parse origin/master)
+                    newest_sha=$(git rev-parse HEAD)
+                    ./vendor/bin/phpcs \
+                    --standard=Silverorange \
+                    --tab-width=4 \
+                    --encoding=utf-8 \
+                    --warning-severity=0 \
+                    --extensions=php \
+                    $(git diff --diff-filter=ACRM --name-only $master_sha...$newest_sha)
+                '''
+            }
+        }
+
+        stage('Lint Entire Project') {
+            when {
+                branch 'master'
+            }
+            steps {
+                sh './vendor/bin/phpcs'
+            }
+        }
+    }
+}

--- a/bin/package-release
+++ b/bin/package-release
@@ -1,8 +1,6 @@
 #!/usr/bin/php
 <?php
 
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
-
 /**
  * @package   PackageRelease
  * @author    Michael Gauthier <mike@silverorange.com>
@@ -41,23 +39,14 @@ if ($autoloader === null) {
     require_once $autoloader;
 }
 
-use Monolog\Logger;
-use Monolog\Formatter\LineFormatter;
-use Monolog\Handler\StreamHandler;
-use Monolog\Processor\PsrLogMessageProcessor;
 use silverorange\PackageRelease;
 
-$output_handler = new StreamHandler('php://stdout', Logger::DEBUG);
-$output_handler->setFormatter(new LineFormatter('%message%' . PHP_EOL));
+$verbosity_handler = new PackageRelease\VerbosityHandler();
 
-$verbosity_handler = new PackageRelease\VerbosityHandler($output_handler);
-
-$logger = new Logger('package-release-cli');
-$logger->pushProcessor(new PsrLogMessageProcessor());
-$logger->pushHandler($verbosity_handler);
+$output = new PackageRelease\Output($verbosity_handler);
 
 $manager = new PackageRelease\Manager();
-$prompt = new PackageRelease\Prompt($logger);
+$prompt = new PackageRelease\Prompt($output);
 
 $parser = \Console_CommandLine::fromXmlFile(__DIR__ . '/../data/cli.xml');
 
@@ -65,7 +54,7 @@ $cli = new PackageRelease\CLI(
     $parser,
     $manager,
     $verbosity_handler,
-    $logger,
+    $output,
     $prompt
 );
 

--- a/composer.json
+++ b/composer.json
@@ -15,15 +15,16 @@
         "php": ">=5.3.0",
         "ext-json": "*",
         "monolog/monolog": "^1.19.0",
-        "pear/console_commandline": "^1.1.10"
+        "pear/console_commandline": "^1.1.10",
+        "martin-pettersson/chalk": "^0.1.3"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "^2.6.0"
+        "silverorange/coding-standard": "^0.7.0"
     },
     "scripts": {
-        "lint": [
-            "phpcs --standard=PSR2 src/"
-        ]
+        "lint": "./vendor/bin/phpcs",
+        "post-install-cmd": "./vendor/bin/phpcs --config-set installed_paths vendor/silverorange/coding-standard/src",
+        "post-update-cmd": "./vendor/bin/phpcs --config-set installed_paths vendor/silverorange/coding-standard/src"
     },
     "bin": [
         "bin/package-release"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
     "require": {
         "php": ">=5.3.0",
         "ext-json": "*",
-        "monolog/monolog": "^1.19.0",
         "pear/console_commandline": "^1.1.10",
         "martin-pettersson/chalk": "^0.1.3"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,65 +4,29 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "1479fd77c262714f42df6090bec7c812",
-    "content-hash": "dff44d2d7ec8e127947f0fad980e7fac",
+    "content-hash": "efcde5c3c9564a462d9fd119e4bb6a75",
     "packages": [
         {
-            "name": "monolog/monolog",
-            "version": "1.19.0",
+            "name": "martin-pettersson/chalk",
+            "version": "0.1.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "5f56ed5212dc509c8dc8caeba2715732abb32dbf"
+                "url": "https://github.com/martin-pettersson/chalk.git",
+                "reference": "a4726d6835bdc7eb3c8c77b2df69fa1b9fddb4c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/5f56ed5212dc509c8dc8caeba2715732abb32dbf",
-                "reference": "5f56ed5212dc509c8dc8caeba2715732abb32dbf",
+                "url": "https://api.github.com/repos/martin-pettersson/chalk/zipball/a4726d6835bdc7eb3c8c77b2df69fa1b9fddb4c5",
+                "reference": "a4726d6835bdc7eb3c8c77b2df69fa1b9fddb4c5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0",
-                "psr/log": "~1.0"
-            },
-            "provide": {
-                "psr/log-implementation": "1.0.0"
-            },
-            "require-dev": {
-                "aws/aws-sdk-php": "^2.4.9",
-                "doctrine/couchdb": "~1.0@dev",
-                "graylog2/gelf-php": "~1.0",
-                "jakub-onderka/php-parallel-lint": "0.9",
-                "php-amqplib/php-amqplib": "~2.4",
-                "php-console/php-console": "^3.1.3",
-                "phpunit/phpunit": "~4.5",
-                "phpunit/phpunit-mock-objects": "2.3.0",
-                "raven/raven": "^0.13",
-                "ruflin/elastica": ">=0.90 <3.0",
-                "swiftmailer/swiftmailer": "~5.3"
-            },
-            "suggest": {
-                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
-                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
-                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
-                "ext-mongo": "Allow sending log messages to a MongoDB server",
-                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
-                "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
-                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
-                "php-console/php-console": "Allow sending log messages to Google Chrome",
-                "raven/raven": "Allow sending log messages to a Sentry server",
-                "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+                "php": ">=5.4"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
-                    "Monolog\\": "src/Monolog"
+                    "Chalk\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -71,39 +35,40 @@
             ],
             "authors": [
                 {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
+                    "name": "Martin Pettersson",
+                    "email": "martin_pettersson@outlook.com",
+                    "homepage": "http://martindotcom.se",
+                    "role": "Developer"
                 }
             ],
-            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-            "homepage": "http://github.com/Seldaek/monolog",
+            "description": "A tool to style terminal output",
+            "homepage": "http://github.com/martin-pettersson/chalk",
             "keywords": [
-                "log",
-                "logging",
-                "psr-3"
+                "chalk",
+                "color",
+                "style"
             ],
-            "time": "2016-04-12 18:29:35"
+            "time": "2016-08-31T08:35:49+00:00"
         },
         {
             "name": "pear/console_commandline",
-            "version": "v1.2.1",
+            "version": "v1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pear/Console_CommandLine.git",
-                "reference": "cdcf721e6d8a5a217765b548b0bc843018e61b4d"
+                "reference": "7a8afa50bdc8dbfdc0cf394f1101106e8b8f8e67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pear/Console_CommandLine/zipball/cdcf721e6d8a5a217765b548b0bc843018e61b4d",
-                "reference": "cdcf721e6d8a5a217765b548b0bc843018e61b4d",
+                "url": "https://api.github.com/repos/pear/Console_CommandLine/zipball/7a8afa50bdc8dbfdc0cf394f1101106e8b8f8e67",
+                "reference": "7a8afa50bdc8dbfdc0cf394f1101106e8b8f8e67",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xml": "*",
                 "pear/pear_exception": "^1.0.0",
-                "php": ">=5.1.0"
+                "php": ">=5.3.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "*"
@@ -136,7 +101,7 @@
             "keywords": [
                 "console"
             ],
-            "time": "2015-12-10 19:54:57"
+            "time": "2016-07-14T06:00:57+00:00"
         },
         {
             "name": "pear/pear_exception",
@@ -191,26 +156,31 @@
             "keywords": [
                 "exception"
             ],
-            "time": "2015-02-10 20:07:52"
-        },
+            "time": "2015-02-10T20:07:52+00:00"
+        }
+    ],
+    "packages-dev": [
         {
-            "name": "psr/log",
-            "version": "1.0.0",
+            "name": "silverorange/coding-standard",
+            "version": "0.7.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b"
+                "url": "https://github.com/silverorange/coding-standard.git",
+                "reference": "c43f3ccabbcb5d4231599d769910868742f8962c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe0936ee26643249e916849d48e3a51d5f5e278b",
-                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "url": "https://api.github.com/repos/silverorange/coding-standard/zipball/c43f3ccabbcb5d4231599d769910868742f8962c",
+                "reference": "c43f3ccabbcb5d4231599d769910868742f8962c",
                 "shasum": ""
+            },
+            "require": {
+                "squizlabs/php_codesniffer": "^3.0.0"
             },
             "type": "library",
             "autoload": {
-                "psr-0": {
-                    "Psr\\Log\\": ""
+                "psr-4": {
+                    "silverorange\\CodingStandard\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -219,79 +189,50 @@
             ],
             "authors": [
                 {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "name": "Michael Gauthier",
+                    "email": "mike@silverorange.com"
                 }
             ],
-            "description": "Common interface for logging libraries",
+            "description": "silverorange PHP coding standards.",
+            "homepage": "https://github.com/silverorange/coding_standard",
             "keywords": [
-                "log",
-                "psr",
-                "psr-3"
+                "phpcs",
+                "silverorange"
             ],
-            "time": "2012-12-21 11:40:51"
-        }
-    ],
-    "packages-dev": [
+            "time": "2017-12-13T21:34:43+00:00"
+        },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.6.1",
+            "version": "3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "fb72ed32f8418db5e7770be1653e62e0d6f5dd3d"
+                "reference": "d7c00c3000ac0ce79c96fcbfef86b49a71158cd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/fb72ed32f8418db5e7770be1653e62e0d6f5dd3d",
-                "reference": "fb72ed32f8418db5e7770be1653e62e0d6f5dd3d",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d7c00c3000ac0ce79c96fcbfef86b49a71158cd1",
+                "reference": "d7c00c3000ac0ce79c96fcbfef86b49a71158cd1",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=5.1.2"
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
             },
             "bin": [
-                "scripts/phpcs",
-                "scripts/phpcbf"
+                "bin/phpcs",
+                "bin/phpcbf"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "3.x-dev"
                 }
-            },
-            "autoload": {
-                "classmap": [
-                    "CodeSniffer.php",
-                    "CodeSniffer/CLI.php",
-                    "CodeSniffer/Exception.php",
-                    "CodeSniffer/File.php",
-                    "CodeSniffer/Fixer.php",
-                    "CodeSniffer/Report.php",
-                    "CodeSniffer/Reporting.php",
-                    "CodeSniffer/Sniff.php",
-                    "CodeSniffer/Tokens.php",
-                    "CodeSniffer/Reports/",
-                    "CodeSniffer/Tokenizers/",
-                    "CodeSniffer/DocGenerators/",
-                    "CodeSniffer/Standards/AbstractPatternSniff.php",
-                    "CodeSniffer/Standards/AbstractScopeSniff.php",
-                    "CodeSniffer/Standards/AbstractVariableSniff.php",
-                    "CodeSniffer/Standards/IncorrectPatternException.php",
-                    "CodeSniffer/Standards/Generic/Sniffs/",
-                    "CodeSniffer/Standards/MySource/Sniffs/",
-                    "CodeSniffer/Standards/PEAR/Sniffs/",
-                    "CodeSniffer/Standards/PSR1/Sniffs/",
-                    "CodeSniffer/Standards/PSR2/Sniffs/",
-                    "CodeSniffer/Standards/Squiz/Sniffs/",
-                    "CodeSniffer/Standards/Zend/Sniffs/"
-                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -309,7 +250,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-05-30 22:24:32"
+            "time": "2017-12-19T21:44:46+00:00"
         }
     ],
     "aliases": [],

--- a/data/cli.xml
+++ b/data/cli.xml
@@ -28,16 +28,10 @@
         <description>Release type. Must be one of "major", "minor", or "patch". If not specified, "minor" is used. Semver 2.0 (https://semver.org/) is used to pick the next release number.</description>
         <action>StoreString</action>
     </option>
-    <option name="verbose">
-        <short_name>-v</short_name>
-        <long_name>--verbose</long_name>
-        <description>Sets verbosity level. Use multiples for more detail (e.g. "-vv").</description>
-        <action>Counter</action>
-    </option>
     <option name="quiet">
         <short_name>-q</short_name>
         <long_name>--quiet</long_name>
-        <description>Turn off all output.</description>
+        <description>Turn off all output. Assumes --yes.</description>
         <action>StoreTrue</action>
     </option>
     <option name="yes">

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<ruleset name="PackageRelease">
+    <arg name="colors"/>
+    <arg name="tab-width" value="4"/>
+    <arg name="extensions" value="php"/>
+    <arg name="encoding" value="utf-8"/>
+    <arg name="warning-severity" value="0"/>
+    <arg value="p" /><!-- show progress -->
+
+    <file>./src</file>
+    <file>./bin</file>
+
+    <rule ref="Silverorange"/>
+</ruleset>

--- a/src/CLI.php
+++ b/src/CLI.php
@@ -88,7 +88,7 @@ class CLI
             $this->verbosity_handler->setIsQuiet($result->options['quiet']);
 
             if (!$this->manager->isInGitRepo()) {
-                $this->output->error(
+                $this->output->out(
                     'This tool must be run from a git repository.'
                     . PHP_EOL . PHP_EOL
                 );
@@ -96,7 +96,7 @@ class CLI
             }
 
             if (!$this->manager->isComposerPackage()) {
-                $this->output->error(
+                $this->output->out(
                     sprintf(
                         'Could not find %s. Make sure you are in the project '
                         . 'root and the project is a composer package.'
@@ -109,7 +109,7 @@ class CLI
 
             $repo_name = $this->manager->getRepoName();
             if ($repo_name === null) {
-                $this->output->error(
+                $this->output->out(
                     sprintf(
                         'Could not find git repository name. Git repository '
                         . 'must have a remote named %s.' . PHP_EOL . PHP_EOL,
@@ -125,7 +125,7 @@ class CLI
             );
             $remote = $this->manager->getRemoteByUrl($remote_url);
             if ($remote === null) {
-                $this->output->error(
+                $this->output->out(
                     sprintf(
                         'Could not find silverorange remote. A remote with the '
                         . 'URL %s must exist.' . PHP_EOL . PHP_EOL,
@@ -139,7 +139,7 @@ class CLI
                 $remote
             );
             if ($current_version === '0.0.0') {
-                $this->output->warn(
+                $this->output->out(
                     Chalk::cyan(
                         'No existing release. Next release will be first '
                         . 'release.' . PHP_EOL
@@ -166,7 +166,7 @@ class CLI
                 );
 
                 if (!$continue) {
-                    $this->output->notice(
+                    $this->output->out(
                         Chalk::style(
                             'Got it. Not releasing.',
                             new Style([ Color::BLACK, Style::BOLD ])
@@ -177,7 +177,7 @@ class CLI
                 }
             }
 
-            $this->output->notice(
+            $this->output->out(
                 Chalk::style(
                     sprintf(
                         'Releasing version %s:' . PHP_EOL,
@@ -186,7 +186,7 @@ class CLI
                     new Style([Color::BLACK, Style::UNDERLINED, Style::BOLD])
                 )
             );
-            $this->output->notice(PHP_EOL);
+            $this->output->out(PHP_EOL);
 
             $branch = $result->options['branch'];
             $this->startCommand();
@@ -279,9 +279,9 @@ class CLI
                 );
             }
 
-            $this->output->notice(PHP_EOL);
-            $this->output->notice(Chalk::green('Success!') . PHP_EOL . PHP_EOL);
-            $this->output->notice(
+            $this->output->out(PHP_EOL);
+            $this->output->out(Chalk::green('Success!') . PHP_EOL . PHP_EOL);
+            $this->output->out(
                 sprintf(
                     'The composer repository will automatically update. It '.
                     'may take a few minutes for the release to appear at %s.'
@@ -290,23 +290,23 @@ class CLI
                 )
             );
         } catch (\Console_CommandLine_Exception $e) {
-            $this->output->error($e->getMessage());
+            $this->output->out($e->getMessage());
             exit(1);
         } catch (\Exception $e) {
-            $this->output->error($e->getMessage());
-            $this->output->error($e->getTraceAsString());
+            $this->output->out($e->getMessage());
+            $this->output->out($e->getTraceAsString());
             exit(1);
         }
     }
 
     protected function startCommand()
     {
-        $this->output->notice(Chalk::dark_gray('… '));
+        $this->output->out(Chalk::dark_gray('… '));
     }
 
     protected function handleSuccess($message)
     {
-        $this->output->notice(
+        $this->output->out(
             sprintf(
                 "\r%s %s" . PHP_EOL,
                 Chalk::green('✓'),
@@ -317,7 +317,7 @@ class CLI
 
     protected function handleError($message, $debug_output)
     {
-        $this->output->error(
+        $this->output->out(
             sprintf(
                 "\r%s %s" . PHP_EOL . PHP_EOL . '%s' . PHP_EOL,
                 Chalk::red('✗'),

--- a/src/CLI.php
+++ b/src/CLI.php
@@ -85,15 +85,7 @@ class CLI
         try {
             $result = $this->parser->parse();
 
-            if ($result->options['quiet']) {
-                $this->verbosity_handler->setVerbosity(
-                    VerbosityHandler::VERBOSITY_QUIET
-                );
-            } else {
-                $this->verbosity_handler->setVerbosity(
-                    $result->options['verbose'] + VerbosityHandler::VERBOSITY_NORMAL
-                );
-            }
+            $this->verbosity_handler->setIsQuiet($result->options['quiet']);
 
             if (!$this->manager->isInGitRepo()) {
                 $this->output->error(
@@ -161,7 +153,7 @@ class CLI
             );
 
             // Prompt to continue release.
-            if (!$result->options['yes']) {
+            if (!$result->options['yes'] && !$result->options['quiet']) {
                 $continue = $this->prompt->ask(
                     sprintf(
                         'Ready to release new %s version %s. '

--- a/src/CLI.php
+++ b/src/CLI.php
@@ -290,11 +290,11 @@ class CLI
                 )
             );
         } catch (\Console_CommandLine_Exception $e) {
-            $this->output->out($e->getMessage());
+            $this->output->out($e->getMessage() . PHP_EOL . PHP_EOL);
             exit(1);
         } catch (\Exception $e) {
-            $this->output->out($e->getMessage());
-            $this->output->out($e->getTraceAsString());
+            $this->output->out($e->getMessage() . PHP_EOL . PHP_EOL);
+            $this->output->out($e->getTraceAsString() . PHP_EOL . PHP_EOL);
             exit(1);
         }
     }

--- a/src/CLI.php
+++ b/src/CLI.php
@@ -98,14 +98,19 @@ class CLI
             if (!$this->manager->isInGitRepo()) {
                 $this->output->error(
                     'This tool must be run from a git repository.'
+                    . PHP_EOL . PHP_EOL
                 );
                 exit(1);
             }
 
             if (!$this->manager->isComposerPackage()) {
                 $this->output->error(
-                    'Could not find “composer.json”. Make sure you are in '
-                    . 'the project root and the project is a composer package.'
+                    sprintf(
+                        'Could not find %s. Make sure you are in the project '
+                        . 'root and the project is a composer package.'
+                        . PHP_EOL . PHP_EOL,
+                        Chalk::magenta('composer.json')
+                    )
                 );
                 exit(1);
             }
@@ -113,8 +118,11 @@ class CLI
             $repo_name = $this->manager->getRepoName();
             if ($repo_name === null) {
                 $this->output->error(
-                    'Could not find git repository name. Git repository '
-                    . 'must have a remote named “origin”.'
+                    sprintf(
+                        'Could not find git repository name. Git repository '
+                        . 'must have a remote named %s.' . PHP_EOL . PHP_EOL,
+                        Chalk::magenta('origin')
+                    )
                 );
                 exit(1);
             }
@@ -128,8 +136,8 @@ class CLI
                 $this->output->error(
                     sprintf(
                         'Could not find silverorange remote. A remote with the '
-                        . 'URL “%s” must exist.',
-                        $remote_url
+                        . 'URL %s must exist.' . PHP_EOL . PHP_EOL,
+                        Chalk::magenta($remote_url)
                     )
                 );
                 exit(1);

--- a/src/CLI.php
+++ b/src/CLI.php
@@ -1,10 +1,10 @@
 <?php
 
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
-
 namespace silverorange\PackageRelease;
 
-use Psr\Log;
+use Chalk\Chalk;
+use Chalk\Style;
+use Chalk\Color;
 
 /**
  * @package   PackageRelease
@@ -12,7 +12,7 @@ use Psr\Log;
  * @copyright 2016 silverorange
  * @license   http://www.opensource.org/licenses/mit-license.html MIT License
  */
-class CLI implements Log\LoggerAwareInterface
+class CLI
 {
     /**
      * @var \Console_CommandLine
@@ -27,17 +27,17 @@ class CLI implements Log\LoggerAwareInterface
     /**
      * The logging interface of this application.
      *
-     * @var \Psr\Log\LoggingInterface
+     * @var silverorange\PackageRelease\Output
      */
-    protected $logger = null;
+    protected $output = null;
 
     /**
-     * @var \silverorange\PackageRelease\VerbosityHandler
+     * @var silverorange\PackageRelease\VerbosityHandler
      */
     protected $verbosity_handler = null;
 
     /**
-     * @var \silverorange\PackageRelease\Prompt
+     * @var silverorange\PackageRelease\Prompt
      */
     protected $prompt = null;
 
@@ -45,13 +45,13 @@ class CLI implements Log\LoggerAwareInterface
         \Console_CommandLine $parser,
         Manager $manager,
         VerbosityHandler $handler,
-        Log\LoggerInterface $logger,
+        Output $output,
         Prompt $prompt
     ) {
         $this->setParser($parser);
         $this->setManager($manager);
         $this->setVerbosityHandler($handler);
-        $this->setLogger($logger);
+        $this->setOutput($output);
         $this->setPrompt($prompt);
     }
 
@@ -70,9 +70,9 @@ class CLI implements Log\LoggerAwareInterface
         $this->verbosity_handler = $handler;
     }
 
-    public function setLogger(Log\LoggerInterface $logger)
+    public function setOutput(Output $output)
     {
-        $this->logger = $logger;
+        $this->output = $output;
     }
 
     public function setPrompt(Prompt $prompt)
@@ -91,20 +91,20 @@ class CLI implements Log\LoggerAwareInterface
                 );
             } else {
                 $this->verbosity_handler->setVerbosity(
-                    $result->options['verbose'] + VerbosityHandler::VERBOSITY_VERBOSE
+                    $result->options['verbose'] + VerbosityHandler::VERBOSITY_NORMAL
                 );
             }
 
             if (!$this->manager->isInGitRepo()) {
-                $this->logger->error(
+                $this->output->error(
                     'This tool must be run from a git repository.'
                 );
                 exit(1);
             }
 
             if (!$this->manager->isComposerPackage()) {
-                $this->logger->error(
-                    'Could not find "composer.json". Make sure you are in '
+                $this->output->error(
+                    'Could not find “composer.json”. Make sure you are in '
                     . 'the project root and the project is a composer package.'
                 );
                 exit(1);
@@ -112,9 +112,9 @@ class CLI implements Log\LoggerAwareInterface
 
             $repo_name = $this->manager->getRepoName();
             if ($repo_name === null) {
-                $this->logger->error(
+                $this->output->error(
                     'Could not find git repository name. Git repository '
-                    . 'must have a remote named "origin".'
+                    . 'must have a remote named “origin”.'
                 );
                 exit(1);
             }
@@ -125,11 +125,11 @@ class CLI implements Log\LoggerAwareInterface
             );
             $remote = $this->manager->getRemoteByUrl($remote_url);
             if ($remote === null) {
-                $this->logger->error(
-                    'Could not find silverorange remote. A remote with the '
-                    . 'URL "{remote}" must exist.',
-                    array(
-                        'remote' => $remote_url,
+                $this->output->error(
+                    sprintf(
+                        'Could not find silverorange remote. A remote with the '
+                        . 'URL “%s” must exist.',
+                        $remote_url
                     )
                 );
                 exit(1);
@@ -139,8 +139,11 @@ class CLI implements Log\LoggerAwareInterface
                 $remote
             );
             if ($current_version === '0.0.0') {
-                $this->logger->warn(
-                    'No existing release. Next release will be first release.'
+                $this->output->warn(
+                    Chalk::cyan(
+                        'No existing release. Next release will be first '
+                        . 'release.' . PHP_EOL
+                    )
                 );
             }
 
@@ -153,47 +156,58 @@ class CLI implements Log\LoggerAwareInterface
             if (!$result->options['yes']) {
                 $continue = $this->prompt->ask(
                     sprintf(
-                        'Ready to release new %s version %s. Continue? [Y/N]',
+                        'Ready to release new %s version %s. '
+                        . 'Continue? %s' . PHP_EOL,
                         $result->options['type'],
-                        $next_version
+                        Chalk::magenta($next_version),
+                        Chalk::yellow('[Y/N]')
                     ),
-                    ' => '
+                    Chalk::yellow('> ')
                 );
 
                 if (!$continue) {
-                    $this->logger->notice('Go it. Not releasing.');
+                    $this->output->notice(
+                        Chalk::style(
+                            'Got it. Not releasing.',
+                            new Style([ Color::BLACK, Style::BOLD ])
+                        )
+                        . PHP_EOL . PHP_EOL
+                    );
                     exit(0);
                 }
             }
 
-            $this->logger->notice(
-                'Releasing version {version}:',
-                array(
-                    'version' => $next_version,
+            $this->output->notice(
+                Chalk::style(
+                    sprintf(
+                        'Releasing version %s:' . PHP_EOL,
+                        $next_version
+                    ),
+                    new Style([Color::BLACK, Style::UNDERLINED, Style::BOLD])
                 )
             );
-            $this->logger->notice('');
+            $this->output->notice(PHP_EOL);
 
             $branch = $result->options['branch'];
+            $this->startCommand();
             $release_branch = $this->manager->createReleaseBranch(
                 $branch,
                 $remote,
                 $next_version
             );
             if ($release_branch === null) {
-                $this->logger->error(
-                    'Could not create release branch from "{branch}". A branch '
-                    . 'with the same name may already exist.',
-                    array(
-                        'branch' => $branch,
-                    )
+                $this->handleError(
+                    sprintf(
+                        'could not create release branch from %s',
+                        Chalk::magenta($branch)
+                    ),
+                    $this->manager->getLastError()
                 );
-                exit(1);
             } else {
-                $this->logger->notice(
-                    '=> created release branch "{branch}".',
-                    array(
-                        'branch' => $release_branch,
+                $this->handleSuccess(
+                    sprintf(
+                        'created release branch %s',
+                        Chalk::magenta($release_branch)
                     )
                 );
             }
@@ -206,71 +220,118 @@ class CLI implements Log\LoggerAwareInterface
             } else {
                 $message = $result->options['message'];
             }
+            $this->startCommand();
             $success = $this->manager->createReleaseTag(
                 $next_version,
                 $message
             );
             if ($success) {
-                $this->logger->notice(
-                    '=> tagged release with message "{message}".',
-                    array(
-                        'message' => $message,
+                $this->handleSuccess(
+                    sprintf(
+                        'tagged release with message %s',
+                        Chalk::magenta($message)
                     )
                 );
             } else {
-                $this->logger->error(
-                    'Failed to create release tag for "{tag}".',
-                    array(
-                        'tag' => $next_version,
-                    )
+                $this->handleError(
+                    sprintf(
+                        'failed to create release tag for %s',
+                        Chalk::magenta($next_version)
+                    ),
+                    $this->manager->getLastError()
                 );
-                exit(1);
             }
 
+            $this->startCommand();
             if ($this->manager->pushTagToRemote($next_version, $remote)) {
-                $this->logger->notice(
-                    '=> pushed tag to "{remote}".',
-                    array(
-                        'remote' => $remote,
+                $this->handleSuccess(
+                    sprintf(
+                        'pushed tag to %s',
+                        Chalk::magenta($remote)
                     )
                 );
             } else {
-                $this->logger->error(
-                    'Could not push tag "{tag}" to remote "{remote}".',
-                    array(
-                        'tag' => $next_version,
-                        'remote' => $remote,
-                    )
+                $this->handleError(
+                    sprintf(
+                        'could not push tag %s to remote %s',
+                        Chalk::magenta($next_version),
+                        Chalk::magenta($remote)
+                    ),
+                    $this->manager->getLastError()
                 );
-                exit(1);
             }
 
+            $this->startCommand();
             if ($this->manager->deleteBranch($release_branch)) {
-                $this->logger->notice(
-                    '=> removed release branch "{branch}".',
-                    array(
-                        'branch' => $release_branch,
+                $this->handleSuccess(
+                    sprintf(
+                        'removed release branch %s',
+                        Chalk::magenta($release_branch)
                     )
                 );
             } else {
-                $this->logger->error(
-                    'Could not delete release branch "{branch}".',
-                    array(
-                        'branch' => $release_branch,
-                    )
+                $this->handleError(
+                    sprintf(
+                        'could not delete release branch %s',
+                        Chalk::magenta($release_branch)
+                    ),
+                    $this->manager->getLastError()
                 );
-                exit(1);
             }
 
-            $this->logger->notice('');
-            $this->logger->notice('Done.');
+            $this->output->notice(PHP_EOL);
+            $this->output->notice(Chalk::green('Success!') . PHP_EOL . PHP_EOL);
+            $this->output->notice(
+                sprintf(
+                    'The composer repository will automatically update. It '.
+                    'may take a few minutes for the release to appear at %s.'
+                    . PHP_EOL . PHP_EOL,
+                    Chalk::blue('https://composer/')
+                )
+            );
         } catch (\Console_CommandLine_Exception $e) {
-            $this->logger->error($e->getMessage());
+            $this->output->error($e->getMessage());
             exit(1);
         } catch (\Exception $e) {
-            $this->logger->error($e->getMessage());
-            $this->logger->error($e->getTraceAsString());
+            $this->output->error($e->getMessage());
+            $this->output->error($e->getTraceAsString());
             exit(1);
         }
+    }
+
+    protected function startCommand()
+    {
+        $this->output->notice(Chalk::dark_gray('… '));
+    }
+
+    protected function handleSuccess($message)
+    {
+        $this->output->notice(
+            sprintf(
+                "\r%s %s" . PHP_EOL,
+                Chalk::green('✓'),
+                $message
+            )
+        );
+    }
+
+    protected function handleError($message, $debug_output)
+    {
+        $this->output->error(
+            sprintf(
+                "\r%s %s" . PHP_EOL . PHP_EOL . '%s' . PHP_EOL,
+                Chalk::red('✗'),
+                $message,
+                Chalk::style(
+                    $this->output->wrap(
+                        $debug_output,
+                        76,
+                        '  '
+                    ),
+                    new Style([ Style::DIM ])
+                )
+            )
+        );
+        exit(1);
     }
 }

--- a/src/CLI.php
+++ b/src/CLI.php
@@ -169,7 +169,7 @@ class CLI
                     $this->output->out(
                         Chalk::style(
                             'Got it. Not releasing.',
-                            new Style([ Color::BLACK, Style::BOLD ])
+                            new Style([ Style::BOLD ])
                         )
                         . PHP_EOL . PHP_EOL
                     );
@@ -183,7 +183,7 @@ class CLI
                         'Releasing version %s:' . PHP_EOL,
                         $next_version
                     ),
-                    new Style([Color::BLACK, Style::UNDERLINED, Style::BOLD])
+                    new Style([ Style::UNDERLINED, Style::BOLD ])
                 )
             );
             $this->output->out(PHP_EOL);

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -1,7 +1,5 @@
 <?php
 
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
-
 namespace silverorange\PackageRelease;
 
 /**

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -136,7 +136,6 @@ class Manager
         $return = 0;
         exec($fetch_command, $output, $return);
         if ($return === 0) {
-
             $checkout_command = sprintf(
                 'git checkout -q -b %s %s/%s',
                 $escaped_release,
@@ -151,7 +150,6 @@ class Manager
             if ($return !== 0) {
                 $release = null;
             }
-
         } else {
             $release = null;
         }

--- a/src/Output.php
+++ b/src/Output.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace silverorange\PackageRelease;
+
+/**
+ * @package   PackageRelease
+ * @author    Michael Gauthier <mike@silverorange.com>
+ * @copyright 2017 silverorange
+ * @license   http://www.opensource.org/licenses/mit-license.html MIT License
+ */
+class Output
+{
+    /**
+     * @var \silverorange\PackageRelease\VerbosityHandler
+     */
+    protected $verbosity_handler = null;
+
+    /**
+     * @var resource
+     */
+    protected $stdout = null;
+
+    public function __construct(VerbosityHandler $handler)
+    {
+        $this->setVerbosityHandler($handler);
+
+        $this->stdout = fopen('php://stdout', 'w');
+    }
+
+    public function setVerbosityHandler(VerbosityHandler $handler)
+    {
+        $this->verbosity_handler = $handler;
+    }
+
+    public function error($message)
+    {
+        if ($this->verbosity_handler->isHandling()) {
+            fwrite($this->stdout, $message);
+        }
+    }
+
+    public function warn($message)
+    {
+        if ($this->verbosity_handler->isHandling()) {
+            fwrite($this->stdout, $message);
+        }
+    }
+
+    public function notice($message)
+    {
+        if ($this->verbosity_handler->isHandling()) {
+            fwrite($this->stdout, $message);
+        }
+    }
+
+    public function wrap($text, $width = 70, $indent = ' ')
+    {
+        $width = (int)$width;
+
+        // Match anything 1 to $width chars long followed by whitespace or EOS,
+        // otherwise match anything $width chars long
+        $search = '/(.{1,' . $width . '})(?:\s|$)|(.{' . $width . '})/uS';
+        $replace = $indent . '$1$2' . PHP_EOL;
+
+        return preg_replace($search, $replace, $text);
+    }
+}

--- a/src/Output.php
+++ b/src/Output.php
@@ -34,21 +34,21 @@ class Output
 
     public function error($message)
     {
-        if ($this->verbosity_handler->isHandling()) {
+        if (!$this->verbosity_handler->isQuiet()) {
             fwrite($this->stdout, $message);
         }
     }
 
     public function warn($message)
     {
-        if ($this->verbosity_handler->isHandling()) {
+        if (!$this->verbosity_handler->isQuiet()) {
             fwrite($this->stdout, $message);
         }
     }
 
     public function notice($message)
     {
-        if ($this->verbosity_handler->isHandling()) {
+        if (!$this->verbosity_handler->isQuiet()) {
             fwrite($this->stdout, $message);
         }
     }

--- a/src/Output.php
+++ b/src/Output.php
@@ -32,21 +32,7 @@ class Output
         $this->verbosity_handler = $handler;
     }
 
-    public function error($message)
-    {
-        if (!$this->verbosity_handler->isQuiet()) {
-            fwrite($this->stdout, $message);
-        }
-    }
-
-    public function warn($message)
-    {
-        if (!$this->verbosity_handler->isQuiet()) {
-            fwrite($this->stdout, $message);
-        }
-    }
-
-    public function notice($message)
+    public function out($message)
     {
         if (!$this->verbosity_handler->isQuiet()) {
             fwrite($this->stdout, $message);

--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -38,13 +38,13 @@ class Prompt
         $answered = false;
 
         $prompt = ($line2 === null) ? $line1 : $line2;
-        $this->output->notice(PHP_EOL);
+        $this->output->out(PHP_EOL);
 
         while (!$answered) {
             if ($line2 !== null) {
-                $this->output->notice($line1);
+                $this->output->out($line1);
             }
-            $this->output->notice($prompt);
+            $this->output->out($prompt);
             $response = readline();
             if (preg_match('/^y|yes$/i', $response) === 1) {
                 $response = true;
@@ -53,7 +53,7 @@ class Prompt
                 $response = false;
                 $answered = true;
             }
-            $this->output->notice(PHP_EOL);
+            $this->output->out(PHP_EOL);
         }
 
         return $response;

--- a/src/Prompt.php
+++ b/src/Prompt.php
@@ -2,8 +2,6 @@
 
 namespace silverorange\PackageRelease;
 
-use Psr\Log;
-
 /**
  * @package   PackageRelease
  * @author    Michael Gauthier <mike@silverorange.com>
@@ -13,13 +11,13 @@ use Psr\Log;
 class Prompt
 {
     /**
-     * @var Log\LoggerInterface $logger
+     * @var silverorange\PackageRelease\Output
      */
-    protected $logger = null;
+    protected $output = null;
 
-    public function __construct(Log\LoggerInterface $logger)
+    public function __construct(Output $output)
     {
-        $this->logger = $logger;
+        $this->output = $output;
     }
 
     /**
@@ -40,13 +38,14 @@ class Prompt
         $answered = false;
 
         $prompt = ($line2 === null) ? $line1 : $line2;
-        $this->logger->notice('');
+        $this->output->notice(PHP_EOL);
 
         while (!$answered) {
             if ($line2 !== null) {
-                $this->logger->notice($line1);
+                $this->output->notice($line1);
             }
-            $response = readline($prompt);
+            $this->output->notice($prompt);
+            $response = readline();
             if (preg_match('/^y|yes$/i', $response) === 1) {
                 $response = true;
                 $answered = true;
@@ -54,7 +53,7 @@ class Prompt
                 $response = false;
                 $answered = true;
             }
-            $this->logger->notice('');
+            $this->output->notice(PHP_EOL);
         }
 
         return $response;

--- a/src/VerbosityHandler.php
+++ b/src/VerbosityHandler.php
@@ -5,39 +5,40 @@ namespace silverorange\PackageRelease;
 /**
  * @package   PackageRelease
  * @author    Michael Gauthier <mike@silverorange.com>
- * @copyright 2016 silverorange
+ * @copyright 2016-2017 silverorange
  * @license   http://www.opensource.org/licenses/mit-license.html MIT License
  */
 class VerbosityHandler
 {
-    const VERBOSITY_QUIET = 0;
-    const VERBOSITY_NORMAL = 1;
-
     /**
-     * @var integer
+     * @var boolean
      */
-    protected $verbosity = self::VERBOSITY_NORMAL;
+    protected $is_quiet = false;
 
-    public function __construct(
-        $verbosity = self::VERBOSITY_NORMAL
-    ) {
-        $this->setVerbosity($verbosity);
+    public function __construct($is_quiet = false)
+    {
+        $this->setIsQuiet($is_quiet);
     }
 
     /**
-     * Sets the level of verbosity to use for the logger
+     * Sets whether or not output should be suppressed
      *
-     * @param integer $verbosity the verbosity level to use.
+     * @param boolean $is_quiet whether or not output should be suppressed.
      *
      * @return void
      */
-    public function setVerbosity($verbosity)
+    public function setIsQuiet($is_quiet)
     {
-        $this->verbosity = min((integer)$verbosity, self::VERBOSITY_NORMAL);
+        $this->is_quiet = $is_quiet ? true : false;
     }
 
-    public function isHandling($level = self::VERBOSITY_NORMAL)
+    /**
+     * Gets whether or not output should be suppressed
+     *
+     * @return boolean
+     */
+    public function isQuiet()
     {
-        return ($level >= $this->verbosity);
+        return $this->is_quiet;
     }
 }

--- a/src/VerbosityHandler.php
+++ b/src/VerbosityHandler.php
@@ -1,50 +1,26 @@
 <?php
 
-/* vim: set expandtab tabstop=4 shiftwidth=4: */
-
 namespace silverorange\PackageRelease;
 
-use Monolog\Handler\HandlerInterface;
-use Monolog\Handler\HandlerWrapper;
-use Monolog\Logger;
-
 /**
- * Monolog handler warapper that filters a handler based on a set verbosity
- * level
- *
  * @package   PackageRelease
  * @author    Michael Gauthier <mike@silverorange.com>
  * @copyright 2016 silverorange
  * @license   http://www.opensource.org/licenses/mit-license.html MIT License
  */
-class VerbosityHandler extends HandlerWrapper
+class VerbosityHandler
 {
     const VERBOSITY_QUIET = 0;
     const VERBOSITY_NORMAL = 1;
-    const VERBOSITY_VERBOSE  = 2;
-    const VERBOSITY_VERY_VERBOSE  = 3;
-    const VERBOSITY_DEBUG = 4;
 
     /**
      * @var integer
      */
     protected $verbosity = self::VERBOSITY_NORMAL;
 
-    /**
-     * @var array
-     */
-    protected $verbosity_map = array(
-        self::VERBOSITY_NORMAL => Logger::WARNING,
-        self::VERBOSITY_VERBOSE => Logger::NOTICE,
-        self::VERBOSITY_VERY_VERBOSE => Logger::INFO,
-        self::VERBOSITY_DEBUG => Logger::DEBUG,
-    );
-
     public function __construct(
-        HandlerInterface $handler,
         $verbosity = self::VERBOSITY_NORMAL
     ) {
-        parent::__construct($handler);
         $this->setVerbosity($verbosity);
     }
 
@@ -57,17 +33,11 @@ class VerbosityHandler extends HandlerWrapper
      */
     public function setVerbosity($verbosity)
     {
-        $this->verbosity = min((integer)$verbosity, self::VERBOSITY_DEBUG);
+        $this->verbosity = min((integer)$verbosity, self::VERBOSITY_NORMAL);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isHandling(array $record)
+    public function isHandling($level = self::VERBOSITY_NORMAL)
     {
-        return (
-            isset($this->verbosity_map[$this->verbosity])
-            && $record['level'] >= $this->verbosity_map[$this->verbosity]
-        );
+        return ($level >= $this->verbosity);
     }
 }


### PR DESCRIPTION
Inspired by [React's release scripts](https://reactjs.org/blog/2017/12/15/improving-the-repository-infrastructure.html#automated-scripts).

Beautify the user-interface for PHP package-release script.

 - replace monolog with raw output
 - use chalk for colors
 - improve UI messages and formatting
 - drop verbosity option and just have `--quiet` option
 - add Jenkins test
 - use silverorage coding style

Old Output
-----------
<img width="592" alt="screen shot 2017-12-29 at 00 35 51" src="https://user-images.githubusercontent.com/120511/34429563-42c5dd00-ec30-11e7-9c79-d5337420fa74.png">

New Output
------------
<img width="594" alt="screen shot 2017-12-29 at 00 33 02" src="https://user-images.githubusercontent.com/120511/34429536-ebb96d60-ec2f-11e7-81ac-3868ecddd975.png">

Dark Console Output
---------------------
<img width="490" alt="screen shot 2017-12-29 at 14 29 18" src="https://user-images.githubusercontent.com/120511/34444469-c3b10100-eca4-11e7-99bc-df3461b3cc57.png">
