### PR TITLE
Allow hippo

### DIFF
--- a/src/Console/Command/PackageReleaseCommand.php
+++ b/src/Console/Command/PackageReleaseCommand.php
@@ -142,22 +142,37 @@ class PackageReleaseCommand extends Command
             return 1;
         }
 
-        $remote_url = sprintf(
-            'git@github.com:silverorange/%s.git',
-            $repo_name
-        );
-        $remote = $this->manager->getRemoteByUrl($remote_url);
+        // Check HippoEducation first because if we have both, we want to
+        // use the HippoEducation remote.
+        $allowed_orgs = [ 'HippoEducation', 'silverorange' ];
+        foreach ($allowed_orgs as $org_name) {
+            $remote_url = sprintf(
+                'git@github.com:%s/%s.git',
+                $org_name,
+                $repo_name
+            );
+            $remote = $this->manager->getRemoteByUrl($remote_url);
+            if ($remote !== null) {
+                break;
+            }
+        }
         if ($remote === null) {
             $output->writeln([
                 sprintf(
-                    'Could not find silverorange remote. A remote with the '
-                    . 'URL <variable>%s</variable> must exist.',
-                    OutputFormatter::escape($remote_url)
+                    'Could not find valid remote. A remote from one of the '.
+                    'following GitHub orgs must exist: %s.',
+                    OutputFormatter::escape(implode($allowed_orgs, ', '))
                 ),
                 ''
             ]);
             return 1;
         }
+        $output->writeln([
+            sprintf(
+                'Using remote with URL %s for release.',
+                OutputFormatter::escape($remote_url)
+            )
+        ]);
 
         $current_version = $this->manager->getCurrentVersionFromRemote(
             $remote

--- a/src/Console/Command/PackageReleaseCommand.php
+++ b/src/Console/Command/PackageReleaseCommand.php
@@ -157,7 +157,7 @@ class PackageReleaseCommand extends Command
             }
         }
         if ($remote === null) {
-            $formatted_orgs = array_map(function(string $org): string {
+            $formatted_orgs = array_map(function (string $org): string {
                 return sprintf(
                     '<variable>%s</variable>',
                     OutputFormatter::escape($org)

--- a/src/Console/Command/PackageReleaseCommand.php
+++ b/src/Console/Command/PackageReleaseCommand.php
@@ -157,11 +157,18 @@ class PackageReleaseCommand extends Command
             }
         }
         if ($remote === null) {
+            $formatted_orgs = array_map(function($org){
+                return sprintf(
+                    '<variable>%s</variable>',
+                    OutputFormatter::escape($org)
+                );
+            }, $allowed_orgs);
+
             $output->writeln([
                 sprintf(
                     'Could not find valid remote. A remote from one of the '.
-                    'following GitHub orgs must exist: %s.',
-                    OutputFormatter::escape(implode($allowed_orgs, ', '))
+                    'following GitHub organizations must exist: %s.',
+                    implode($formatted_orgs, ', ')
                 ),
                 ''
             ]);

--- a/src/Console/Command/PackageReleaseCommand.php
+++ b/src/Console/Command/PackageReleaseCommand.php
@@ -157,7 +157,7 @@ class PackageReleaseCommand extends Command
             }
         }
         if ($remote === null) {
-            $formatted_orgs = array_map(function($org){
+            $formatted_orgs = array_map(function(string $org): string {
                 return sprintf(
                     '<variable>%s</variable>',
                     OutputFormatter::escape($org)
@@ -166,7 +166,7 @@ class PackageReleaseCommand extends Command
 
             $output->writeln([
                 sprintf(
-                    'Could not find valid remote. A remote from one of the '.
+                    'Could not find a valid remote. A remote from one of the '.
                     'following GitHub organizations must exist: %s.',
                     implode($formatted_orgs, ', ')
                 ),


### PR DESCRIPTION
To test:
- Check out this project on `roble`
- Try to release packages from both the silverorange and Hippo orgs on master and this branch. `master` will only allow packages from the silverorange org; this patch should accept both. (To run, use `/so/packages/package_release/work-NAME/bin/package-release` in the package directory.) 
- The error message can be tested by temporarily removing the hippo/silverorange remote.