### PR TITLE
Include prepare-site as a bin script for package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "post-update-cmd": "./vendor/bin/phpcs --config-set installed_paths vendor/silverorange/coding-standard/src"
     },
     "bin": [
-        "bin/package-release"
+        "bin/package-release",
+        "bin/prepare-site"
     ],
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This will install `prepare-site` in `vendor/bin` like the `package-release` script