### PR TITLE
Suppress error output when fetching before reading remote file

### DIFF
--- a/src/Git/Manager.php
+++ b/src/Git/Manager.php
@@ -418,7 +418,7 @@ class Manager
         string $path
     ): string {
         $command = sprintf(
-            "git fetch %s && git show %s/%s:%s 2>&1",
+            "git fetch %s 2>&1 && git show %s/%s:%s 2>&1",
             escapeshellarg($remote),
             escapeshellarg($remote),
             escapeshellarg($branch),


### PR DESCRIPTION
Testing:

1. check out PR
2. go to non-git directory
3. run `bin/prepare-site` from the non-git directory
4. You should get `This tool must be run from a git repository.` and not get `fatal: not a git repository (or any of the parent directories): .git`