### PR TITLE
Add basic Lerna monorepo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ title = "My Human-Readable Title"  ; Human-readable site title for messages
 
 [testing]
 url = "https://$hostname/testpath" ; URL to visit to perform manual testing
-command = "composer run test"      ; command to run automated tests 
+command = "composer run test"      ; command to run automated tests
 ```
 
 ### Variable Interpolation
@@ -78,6 +78,21 @@ The metadata file may use the following variables inside values:
  - **$branch** - the name of the current Git branch.
 
 Other variables will be ignored and used verbatim.
+
+### Lerna Monorepos
+
+For sites using a lerna monorepo setup, the `scope.is_web` setting is used to control
+which packages are built for a web deployment. Packages are built in the order they appear
+in the metadata file, for example:
+
+```
+[shared]
+scope.is_web = true
+
+[web]
+scope.is_web = true
+
+```
 
 Development
 -----------

--- a/src/Builder/LernaBuilder.php
+++ b/src/Builder/LernaBuilder.php
@@ -27,10 +27,14 @@ class LernaBuilder extends BaseBuilder
 
     public function build(OutputInterface $output): bool
     {
-        return Npm::install($output)
-            && Lerna::verify($output)
-            && Lerna::bootstrap($output)
-            && Lerna::build($output, $this->scopes);
+        $result = Lerna::verify($output)
+            && Lerna::bootstrap($output, $this->scopes);
+
+        foreach($this->scopes as $scope) {
+            $result = $result && Lerna::build($output, $scope);
+        }
+
+        return $result;
     }
 
     public function getTitle(): string

--- a/src/Builder/LernaBuilder.php
+++ b/src/Builder/LernaBuilder.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Silverorange\PackageRelease\Builder;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use Silverorange\PackageRelease\Tool\Npm;
+use Silverorange\PackageRelease\Tool\Lerna;
+
+/**
+ * @package   PackageRelease
+ * @author    Meg Mitchell <meg@silverorange.com>
+ * @copyright 2020 silverorange
+ * @license   http://www.opensource.org/licenses/mit-license.html MIT License
+ */
+class LernaBuilder extends BaseBuilder
+{
+    protected $scopes;
+
+    function __construct(Array $scopes=[]) {
+       $this->scopes = $scopes;
+    }
+
+    public function isAppropriate(): bool
+    {
+        return $this->hasFile('lerna.json');
+    }
+
+    public function build(OutputInterface $output): bool
+    {
+        return Npm::install($output)
+            && Lerna::verify($output)
+            && Lerna::bootstrap($output)
+            && Lerna::build($output, $this->scopes);
+    }
+
+    public function getTitle(): string
+    {
+        return 'Lerna';
+    }
+}

--- a/src/Builder/LernaBuilder.php
+++ b/src/Builder/LernaBuilder.php
@@ -27,8 +27,7 @@ class LernaBuilder extends BaseBuilder
 
     public function build(OutputInterface $output): bool
     {
-        $result = Lerna::verify($output)
-            && Lerna::bootstrap($output, $this->scopes);
+        $result = Lerna::bootstrap($output, $this->scopes);
 
         foreach($this->scopes as $scope) {
             $result = $result && Lerna::build($output, $scope);

--- a/src/Console/Command/PrepareSiteCommand.php
+++ b/src/Console/Command/PrepareSiteCommand.php
@@ -144,14 +144,14 @@ class PrepareSiteCommand extends Command
             return 1;
         }
 
-        // if (!$this->isMonoRepo() && !$this->isInLiveDirectory()) {
-        //     $output->writeln([
-        //         'You must be in the site’s <variable>live</variable> '
-        //         . 'directory to prepare a release.',
-        //         ''
-        //     ]);
-        //     return 1;
-        // }
+        if (!$this->isMonoRepo() && !$this->isInLiveDirectory()) {
+            $output->writeln([
+                'You must be in the site’s <variable>live</variable> '
+                . 'directory to prepare a release.',
+                ''
+            ]);
+            return 1;
+        }
 
         if ($this->isMonoRepo() && !$this->isInMonoRepoModule()) {
             $output->writeln([

--- a/src/Tool/Lerna.php
+++ b/src/Tool/Lerna.php
@@ -13,22 +13,9 @@ use Silverorange\PackageRelease\Console\ProcessRunner;
  */
 class Lerna
 {
-    public static function verify(OutputInterface $output): bool
-    {
-        $command = 'yarn global add lerna';
-
-        return (new ProcessRunner(
-            $output,
-            $command,
-            'verifying Lerna installation',
-            'verified Lerna installation',
-            'failed to verify Lerna installation'
-        ))->run();
-    }
-
     public static function bootstrap(OutputInterface $output, Array $scopes): bool
     {
-        $command = 'yarn lerna bootstrap';
+        $command = 'lerna bootstrap';
         foreach ($scopes as $scope) {
             $command .= sprintf(' --scope=%s', $scope);
         }
@@ -44,7 +31,7 @@ class Lerna
 
     public static function build(OutputInterface $output, string $scope): bool
     {
-        $command = sprintf('yarn lerna run build --scope=%s', $scope);
+        $command = sprintf('lerna run build --scope=%s', $scope);
 
         return (new ProcessRunner(
             $output,

--- a/src/Tool/Lerna.php
+++ b/src/Tool/Lerna.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Silverorange\PackageRelease\Tool;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use Silverorange\PackageRelease\Console\ProcessRunner;
+
+/**
+ * @package   PackageRelease
+ * @author    Meg Mitchell <meg@silverorange.com>
+ * @copyright 2020 silverorange
+ * @license   http://www.opensource.org/licenses/mit-license.html MIT License
+ */
+class Lerna
+{
+    public static function verify(OutputInterface $output): bool
+    {
+        $command = 'yarn global add lerna';
+
+        return (new ProcessRunner(
+            $output,
+            $command,
+            'verifying Lerna installation',
+            'verified Lerna installation',
+            'failed to verify Lerna installation'
+        ))->run();
+    }
+
+    public static function bootstrap(OutputInterface $output): bool
+    {
+        $command = 'yarn lerna bootstrap';
+
+        return (new ProcessRunner(
+            $output,
+            $command,
+            'bootstrapping Lerna repository',
+            'bootstrapped Lerna repository',
+            'failed to bootstrap Lerna repository'
+        ))->run();
+    }
+
+    public static function build(OutputInterface $output, Array $scopes): bool
+    {
+        $command = 'yarn lerna run build';
+        foreach ($scopes as $scope) {
+            $command .= sprintf(' --scope=%s', $scope);
+        }
+
+        return (new ProcessRunner(
+            $output,
+            $command,
+            'building Lerna web packages',
+            'built Lerna web packages',
+            'failed to build Lerna web packages'
+        ))->run();
+    }
+}

--- a/src/Tool/Lerna.php
+++ b/src/Tool/Lerna.php
@@ -26,9 +26,12 @@ class Lerna
         ))->run();
     }
 
-    public static function bootstrap(OutputInterface $output): bool
+    public static function bootstrap(OutputInterface $output, Array $scopes): bool
     {
         $command = 'yarn lerna bootstrap';
+        foreach ($scopes as $scope) {
+            $command .= sprintf(' --scope=%s', $scope);
+        }
 
         return (new ProcessRunner(
             $output,
@@ -39,19 +42,16 @@ class Lerna
         ))->run();
     }
 
-    public static function build(OutputInterface $output, Array $scopes): bool
+    public static function build(OutputInterface $output, string $scope): bool
     {
-        $command = 'yarn lerna run build';
-        foreach ($scopes as $scope) {
-            $command .= sprintf(' --scope=%s', $scope);
-        }
+        $command = sprintf('yarn lerna run build --scope=%s', $scope);
 
         return (new ProcessRunner(
             $output,
             $command,
-            'building Lerna web packages',
-            'built Lerna web packages',
-            'failed to build Lerna web packages'
+            sprintf('building Lerna web package "%s"', $scope),
+            sprintf('built Lerna web package "%s"', $scope),
+            sprintf('failed to build Lerna web package "%s"', $scope)
         ))->run();
     }
 }


### PR DESCRIPTION
Adds support for building lerna monorepo projects. 

To test:
- In your video platform working directory, make sure `origin/master` points to a version of the video platform that has the release config added at https://github.com/HippoEducation/video-platform-client/pull/310 . An explanation on how to do this without merging that PR is over there, or you can merge it. :) 
- In your package-release working directory, check out this PR and install (`composer install`). 
- From `/so/video-platform-client/work-**NAME**` run:
```
export PUBLIC_URL=/video-platform-client/work-**NAME**/packages/web/build
export REACT_APP_HOST=https://hippostage.silverorange.com
export REACT_APP_SIGN_IN_URL=https://hippostage.silverorange.com/hippo-ed/work-hive/dist/signin
export REACT_APP_CART_CALLBACK_URI=https://hippostage.silverorange.com/video-platform-client/stage/packages/web/build
export REACT_APP_GA_ACCOUNT=UA-152638193-01
export REACT_APP_GRAPHQL_URI=https://hippostage-api.silverorange.com/graphql
export REACT_APP_JSONAPI_URI=https://hippostage-api.silverorange.com
export REACT_APP_STAGE_SERVER=https://hippostage.silverorange.com
export REACT_APP_STAGE_DIR=work-meg
export REACT_APP_MEDIA_CDN="https://hippo-med-stage.s3.amazonaws.com"
export REACT_APP_CART_URI=http://localhost:6006
export REACT_APP_CART_CALLBACK_URI=https://hippostage.silverorange.com
export REACT_APP_GA_ACCOUNT=UA-152638193-01
export REACT_APP_FRIENDBUY_ACCOUNT=site-1f530c77-www.hippoeducation.com
export REACT_APP_FIREBASE_API_KEY=AIzaSyDaeVS8DrCaL7Evo0qC8_sw5I7tcV1yeXk
export REACT_APP_FIREBASE_AUTH_DOMAIN=hippo-development.firebaseapp.com
export REACT_APP_FIREBASE_PROJECT_ID=hippo-development
export REACT_APP_FIREBASE_STORAGE_BUCKET=hippo-development.appspot.com
export REACT_APP_FIREBASE_MESSAGING_SENDER_ID=306782222008
export REACT_APP_FIREBASE_APP_ID=1:306782222008:web:d8591660d13aba6962264d
/so/packages/package_release/work-**NAME**/bin/prepare-site
```

This should create a **working** web build in your working directory accessible at https://hippostage.silverorange.com/video-platform-client/work-**NAME**/packages/web/build/  

The env vars are set up in order to test that the built code is working without syncing it to prod. When preparing the site for prod, we should just run `prepare-site`; ansible will set up the correct environment variables for us.