### PR TITLE
Update version number of prepare-site

### DIFF
--- a/bin/prepare-site
+++ b/bin/prepare-site
@@ -50,7 +50,7 @@ use Silverorange\PackageRelease\Console\Formatter\Style;
 $manager = new Manager();
 
 $metadata = new ReleaseMetadata($manager, 'release-metadata.ini');
-$application = new Application('Prepare Site', '1.2.0');
+$application = new Application('Prepare Site', '2.5.1');
 
 $command = new PrepareSiteCommand($metadata, $manager, new Style());
 


### PR DESCRIPTION
Current version is 2.5.0, I picked 2.5.1 so I can do a patch release that includes this change.