### PR TITLE
Update Lerna build process to set up appropriate branch names

### DIFF
--- a/bin/prepare-site
+++ b/bin/prepare-site
@@ -50,7 +50,7 @@ use Silverorange\PackageRelease\Console\Formatter\Style;
 $manager = new Manager();
 
 $metadata = new ReleaseMetadata($manager, 'release-metadata.ini');
-$application = new Application('Prepare Site', '2.5.1');
+$application = new Application('Prepare Site', '2.6.0');
 
 $command = new PrepareSiteCommand($metadata, $manager, new Style());
 

--- a/src/Console/Command/PrepareSiteCommand.php
+++ b/src/Console/Command/PrepareSiteCommand.php
@@ -430,6 +430,14 @@ class PrepareSiteCommand extends Command
     {
         $module = $this->getMonoRepoModuleName();
         $module_metadata = $this->release_metadata->get($module);
+        if(!is_array($module_metadata)) {
+          throw new \Exception(
+                'A release metadata file is required to build a Lerna project, ' .
+                'but no metadata could be found.' .
+                "\n" .
+                'Check that origin/master is up to date and pointing to the correct place.'
+            );
+        }
         $packages = array_key_exists('build.prereqs', $module_metadata) ?
             explode(',', $module_metadata['build.prereqs']) : [];
 

--- a/src/Console/Command/PrepareSiteCommand.php
+++ b/src/Console/Command/PrepareSiteCommand.php
@@ -158,14 +158,14 @@ class PrepareSiteCommand extends Command
             return 1;
         }
 
-        // if (!$this->isMonoRepo() && !$this->isInLiveDirectory()) {
-        //     $output->writeln([
-        //         'You must be in the site’s <variable>live</variable> '
-        //         . 'directory to prepare a release.',
-        //         ''
-        //     ]);
-        //     return 1;
-        // }
+        if (!$this->isMonoRepo() && !$this->isInLiveDirectory()) {
+            $output->writeln([
+                'You must be in the site’s <variable>live</variable> '
+                . 'directory to prepare a release.',
+                ''
+            ]);
+            return 1;
+        }
 
         if ($this->isMonoRepo() && !$this->isInMonoRepoModule()) {
             $output->writeln([

--- a/src/Console/Command/PrepareSiteCommand.php
+++ b/src/Console/Command/PrepareSiteCommand.php
@@ -428,6 +428,9 @@ class PrepareSiteCommand extends Command
 
     protected function getLernaPackages(): Array
     {
+        if(!(new LernaBuilder())->isAppropriate()) {
+            return [];
+        }
         $module = $this->getMonoRepoModuleName();
         $module_metadata = $this->release_metadata->get($module);
         if(!is_array($module_metadata)) {


### PR DESCRIPTION
https://airtable.com/tblHi2RES2ktb1XG9/viwWNxHGvw1XPAGLJ/recB6gz0buGFNyiWf?blocks=hide

Extends https://github.com/silverorange/package_release/pull/20

While `release-site` does the actual work of tagging and versioning, it turns out `prepare-site` controls the resulting tag names based on the release branch it creates. E.g., if the branch created is called `release-0-1-0` then the tag will be `0.1.0`, while if the branch is `release-web@0-1-0` then the tag will be `web@0.1.0`. We want to be able to tag lerna packages within a monorepo separately, so this patch updates the branch creation logic for lerna to support that. 

In order to generalize the logic, I also updated the way that package dependencies are managed in the release-metadata.ini file. This will allow us to easily prepare and release multiple different web builds in one lerna monorepo later if we want. 

To test, I used the same steps in https://github.com/silverorange/package_release/pull/20 to set up `prepare-site`. Then to make sure that I got the expected tagging behavior for `release-site`, I used a dev copy of `release-site` and changed `livedir=live` to `livedir=work-meg`. This allows me to release a site from my work directory. Since `origin` is my own working repository and not the main HippoEducation repository, this means the tags ended up getting pushed to my own repo (see here: https://github.com/m-mitchell/video-platform-client/releases).  Some examples I tried:

```
/so/packages/package_release/work-meg/bin/prepare-site
/so/sites/tools/work-meg/package-party/release-site.sh

/so/packages/package_release/work-meg/bin/prepare-site -l web
/so/sites/tools/work-meg/package-party/release-site.sh

/so/packages/package_release/work-meg/bin/prepare-site -l native
/so/sites/tools/work-meg/package-party/release-site.sh

/so/packages/package_release/work-meg/bin/prepare-site -l shared
/so/sites/tools/work-meg/package-party/release-site.sh
``` 