### PR TITLE
Add interactive prompt before selecting release type

### DIFF
--- a/src/Builder/LernaBuilder.php
+++ b/src/Builder/LernaBuilder.php
@@ -14,10 +14,14 @@ use Silverorange\PackageRelease\Tool\Lerna;
  */
 class LernaBuilder extends BaseBuilder
 {
+    /**
+     * @var string[]
+     */
     protected $scopes;
 
-    function __construct(Array $scopes=[]) {
-       $this->scopes = $scopes;
+    public function __construct(array $scopes = [])
+    {
+        $this->scopes = $scopes;
     }
 
     public function isAppropriate(): bool
@@ -29,7 +33,7 @@ class LernaBuilder extends BaseBuilder
     {
         $result = Lerna::bootstrap($output, $this->scopes);
 
-        foreach($this->scopes as $scope) {
+        foreach ($this->scopes as $scope) {
             $result = $result && Lerna::build($output, $scope);
         }
 

--- a/src/Console/Command/PackageReleaseCommand.php
+++ b/src/Console/Command/PackageReleaseCommand.php
@@ -243,6 +243,9 @@ class PackageReleaseCommand extends Command
                     return 0;
                 }
             } else {
+                // It's a non-interactive terminal, or quiet-mode was selected;
+                // and no release type was specified. Default to a minor
+                // release.
                 $type = 'minor';
             }
         }

--- a/src/Console/Command/PackageReleaseCommand.php
+++ b/src/Console/Command/PackageReleaseCommand.php
@@ -197,51 +197,52 @@ class PackageReleaseCommand extends Command
         }
 
         $type = $input->getOption('type');
-        if ($input->isInteractive()
-            && !$output->isQuiet()
-            && $type === 'interactive'
-        ) {
-            $branch = $input->getOption('branch');
-            $this->manager->showDiff($remote, $current_version, $branch);
+        if ($type === 'interactive') {
+            if ($input->isInteractive()
+                && !$output->isQuiet()
+            ) {
+                $branch = $input->getOption('branch');
+                $this->manager->showDiff($remote, $current_version, $branch);
 
-            $prompt = new OptionsPrompt($this->getHelper('question'));
-            $type = $prompt->ask(
-                $input,
-                $output,
-                'Review the diff and choose an appropriate release type:',
-                [
-                    new OptionsPromptOption(
-                        'p',
-                        'patch',
-                        '<bold>[P]</bold>atch ... only bug fixes'
-                    ),
-                    new OptionsPromptOption(
-                        'm',
-                        'minor',
-                        '<bold>[M]</bold>inor ... new, backwards-compatible API or features'
-                    ),
-                    new OptionsPromptOption(
-                        'j',
-                        'major',
-                        'Ma<bold>[j]</bold>or ... backwards-incompatible API changes'
-                    ),
-                    new OptionsPromptOption(
-                        'c',
-                        'cancel',
-                        '<bold>[C]</bold>ancel'
-                    ),
-                ]
-            );
+                $prompt = new OptionsPrompt($this->getHelper('question'));
+                $type = $prompt->ask(
+                    $input,
+                    $output,
+                    'Review the diff and choose an appropriate release type:',
+                    [
+                        new OptionsPromptOption(
+                            'p',
+                            'patch',
+                            '<bold>[P]</bold>atch ... only bug fixes'
+                        ),
+                        new OptionsPromptOption(
+                            'm',
+                            'minor',
+                            '<bold>[M]</bold>inor ... new, '
+                            . 'backwards-compatible API or features'
+                        ),
+                        new OptionsPromptOption(
+                            'j',
+                            'major',
+                            'Ma<bold>[j]</bold>or ... '
+                            . 'backwards-incompatible API changes'
+                        ),
+                        new OptionsPromptOption(
+                            'c',
+                            'cancel',
+                            '<bold>[C]</bold>ancel'
+                        ),
+                    ]
+                );
 
-            if ($type === 'cancel') {
-                $output->writeln([
-                    '<bold>Got it. Not releasing.</bold>',
-                    ''
-                ]);
-                return 0;
-            }
-        } else {
-            if ($type === 'interactive') {
+                if ($type === 'cancel') {
+                    $output->writeln([
+                        '<bold>Got it. Not releasing.</bold>',
+                        ''
+                    ]);
+                    return 0;
+                }
+            } else {
                 $type = 'minor';
             }
         }

--- a/src/Console/Command/PackageReleaseCommand.php
+++ b/src/Console/Command/PackageReleaseCommand.php
@@ -16,6 +16,8 @@ use Silverorange\PackageRelease\Console\Formatter\Style;
 use Silverorange\PackageRelease\Console\Formatter\LineWrapper;
 use Silverorange\PackageRelease\Console\Formatter\OutputFormatter as PackageReleaseOutputFormatter;
 use Silverorange\PackageRelease\Console\Question\ConfirmationPrompt;
+use Silverorange\PackageRelease\Console\Question\OptionsPrompt;
+use Silverorange\PackageRelease\Console\Question\OptionsPromptOption;
 
 /**
  * @package   PackageRelease
@@ -91,8 +93,10 @@ class PackageReleaseCommand extends Command
                         InputOption::VALUE_REQUIRED,
                         'Release type. Must be one of "major", "minor", or '
                         . '"patch". Semver 2.0 (https://semver.org/) is used '
-                        . 'to pick the next release number.',
-                        'minor'
+                        . 'to pick the next release number. If not specified, '
+                        . 'a diff is displayed and this tool prompts for the '
+                        . 'appropriate release type.',
+                        'interactive'
                     ),
                 ))
             );
@@ -192,9 +196,61 @@ class PackageReleaseCommand extends Command
             ]);
         }
 
+        $type = $input->getOption('type');
+        if ($input->isInteractive()
+            && !$output->isQuiet()
+            && $type === 'interactive'
+        ) {
+            $branch = $input->getOption('branch');
+
+            print_r($current_version, $branch);
+            $this->manager->showDiff($remote, $current_version, $branch);
+
+            $prompt = new OptionsPrompt($this->getHelper('question'));
+            $type = $prompt->ask(
+                $input,
+                $output,
+                'Review the diff and choose an appropriate release type:',
+                [
+                    new OptionsPromptOption(
+                        'p',
+                        'patch',
+                        '<bold>[P]</bold>atch ... only bug fixes'
+                    ),
+                    new OptionsPromptOption(
+                        'm',
+                        'minor',
+                        '<bold>[M]</bold>inor ... new, backwards-compatible API or features'
+                    ),
+                    new OptionsPromptOption(
+                        'j',
+                        'major',
+                        'Ma<bold>[j]</bold>or ... backwards-incompatible API changes'
+                    ),
+                    new OptionsPromptOption(
+                        'c',
+                        'cancel',
+                        '<bold>[C]</bold>ancel'
+                    ),
+                ]
+            );
+
+            if ($type === 'cancel') {
+                $output->writeln([
+                    '<bold>Got it. Not releasing.</bold>',
+                    ''
+                ]);
+                return 0;
+            }
+        } else {
+            if ($type === 'interactive') {
+                $type = 'minor';
+            }
+        }
+
         $next_version = $this->manager->getNextVersion(
             $current_version,
-            $input->getOption('type')
+            $type
         );
 
         // Prompt to continue release.
@@ -205,8 +261,8 @@ class PackageReleaseCommand extends Command
                 $output,
                 sprintf(
                     'Ready to release new %s version <variable>%s</variable>. '
-                    . 'Continue? <prompt>[Y/N]</prompt>',
-                    $input->getOption('type'),
+                    . 'Continue? <bold>[Y/N]</bold>',
+                    OutputFormatter::escape($type),
                     OutputFormatter::escape($next_version)
                 )
             );
@@ -351,7 +407,7 @@ class PackageReleaseCommand extends Command
     ): void {
         $type = $input->getOption('type');
 
-        if (!in_array($type, ['major', 'minor', 'patch', 'micro'])) {
+        if (!in_array($type, ['major', 'minor', 'patch', 'micro', 'interactive'])) {
             throw new InvalidOptionException(
                 sprintf(
                     'Option "type" must be one of the following: "major", '

--- a/src/Console/Command/PackageReleaseCommand.php
+++ b/src/Console/Command/PackageReleaseCommand.php
@@ -202,8 +202,6 @@ class PackageReleaseCommand extends Command
             && $type === 'interactive'
         ) {
             $branch = $input->getOption('branch');
-
-            print_r($current_version, $branch);
             $this->manager->showDiff($remote, $current_version, $branch);
 
             $prompt = new OptionsPrompt($this->getHelper('question'));

--- a/src/Console/Command/PrepareSiteCommand.php
+++ b/src/Console/Command/PrepareSiteCommand.php
@@ -426,23 +426,26 @@ class PrepareSiteCommand extends Command
         return $testing_url;
     }
 
-    protected function getLernaPackages(): Array
+    protected function getLernaPackages(): array
     {
-        if(!(new LernaBuilder())->isAppropriate()) {
+        if (!(new LernaBuilder())->isAppropriate()) {
             return [];
         }
+
         $module = $this->getMonoRepoModuleName();
         $module_metadata = $this->release_metadata->get($module);
-        if(!is_array($module_metadata)) {
-          throw new \Exception(
-                'A release metadata file is required to build a Lerna project, ' .
-                'but no metadata could be found.' .
-                "\n" .
-                'Check that origin/master is up to date and pointing to the correct place.'
+        if (!is_array($module_metadata)) {
+            throw new \Exception(
+                'A release metadata file is required to build a Lerna project, '
+                . "but no metadata could be found.\n"
+                . 'Check that origin/master is up to date and pointing to the '
+                . 'correct place.'
             );
         }
-        $packages = array_key_exists('build.prereqs', $module_metadata) ?
-            explode(',', $module_metadata['build.prereqs']) : [];
+
+        $packages = array_key_exists('build.prereqs', $module_metadata)
+            ? explode(',', $module_metadata['build.prereqs'])
+            : [];
 
         $packages[] = $module;
         return $packages;

--- a/src/Console/Question/ConfirmationPrompt.php
+++ b/src/Console/Question/ConfirmationPrompt.php
@@ -25,9 +25,10 @@ class ConfirmationPrompt
         $this->setHelper($helper);
     }
 
-    public function setHelper(QuestionHelper $helper)
+    public function setHelper(QuestionHelper $helper): self
     {
         $this->helper = $helper;
+        return $this;
     }
 
     /**

--- a/src/Console/Question/OptionsPrompt.php
+++ b/src/Console/Question/OptionsPrompt.php
@@ -31,8 +31,8 @@ class OptionsPrompt
     }
 
     /**
-     * Asks a multiple-choice, waits for a response and returns one of the
-     * values
+     * Asks a multiple-choice question, waits for a response and returns one of
+     * the values
      *
      * @param string $prompt  The prompt text to use. This is displayed above
      *                        the input line.

--- a/src/Console/Question/OptionsPrompt.php
+++ b/src/Console/Question/OptionsPrompt.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Silverorange\PackageRelease\Console\Question;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Helper\QuestionHelper;
+
+/**
+ * @package   PackageRelease
+ * @author    Michael Gauthier <mike@silverorange.com>
+ * @copyright 2020 silverorange
+ * @license   http://www.opensource.org/licenses/mit-license.html MIT License
+ */
+class OptionsPrompt
+{
+    /**
+     * @var Symfony\Component\Console\Helper\QuestionHelper
+     */
+    protected $helper = null;
+
+    public function __construct(QuestionHelper $helper)
+    {
+        $this->setHelper($helper);
+    }
+
+    public function setHelper(QuestionHelper $helper)
+    {
+        $this->helper = $helper;
+    }
+
+    /**
+     * Asks a multiple-choice, waits for a response and returns one of the
+     * values
+     *
+     * @param string $prompt  The prompt text to use. This is displayed above
+     *                        the input line.
+     * @param array  $options an array of
+     *                        {@link Silverorange\PackageRelease\Console\Question\OptionPromptOption}
+     *                        objects.
+     *
+     * @return string the selected option value.
+     */
+    public function ask(
+        InputInterface $input,
+        OutputInterface $output,
+        string $prompt,
+        array $options
+    ): string {
+        $answered = false;
+
+        $output->writeln('');
+        $question = new Question('<prompt>></prompt> ', null);
+
+        while (!$answered) {
+            $output->writeln($prompt);
+            $output->writeln('');
+            foreach ($options as $option) {
+                $output->writeln($option->getPrompt());
+            }
+            $output->writeln('');
+            $response = $this->helper->ask($input, $output, $question);
+
+            foreach ($options as $option) {
+                if ($option->matches($response)) {
+                    $value = $option->getValue();
+                    $answered = true;
+                    break 2;
+                }
+            }
+
+            $output->writeln('');
+        }
+
+        return $value;
+    }
+}

--- a/src/Console/Question/OptionsPrompt.php
+++ b/src/Console/Question/OptionsPrompt.php
@@ -25,9 +25,10 @@ class OptionsPrompt
         $this->setHelper($helper);
     }
 
-    public function setHelper(QuestionHelper $helper)
+    public function setHelper(QuestionHelper $helper): self
     {
         $this->helper = $helper;
+        return $this;
     }
 
     /**

--- a/src/Console/Question/OptionsPromptOption.php
+++ b/src/Console/Question/OptionsPromptOption.php
@@ -27,9 +27,10 @@ class OptionsPromptOption
 
     public function __construct(string $key, string $value, string $prompt)
     {
-        $this->setKey($key);
-        $this->setValue($value);
-        $this->setPrompt($prompt);
+        $this
+            ->setKey($key)
+            ->setValue($value)
+            ->setPrompt($prompt);
     }
 
     public function setKey(string $key): self

--- a/src/Console/Question/OptionsPromptOption.php
+++ b/src/Console/Question/OptionsPromptOption.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Silverorange\PackageRelease\Console\Question;
+
+/**
+ * @package   PackageRelease
+ * @author    Michael Gauthier <mike@silverorange.com>
+ * @copyright 2020 silverorange
+ * @license   http://www.opensource.org/licenses/mit-license.html MIT License
+ */
+class OptionsPromptOption
+{
+    /**
+     * @var string
+     */
+    protected $key = '';
+
+    /**
+     * @var string
+     */
+    protected $value = '';
+
+    /**
+     * @var string
+     */
+    protected $prompt = '';
+
+    public function __construct(string $key, string $value, string $prompt)
+    {
+        $this->setKey($key);
+        $this->setValue($value);
+        $this->setPrompt($prompt);
+    }
+
+    public function setKey(string $key): self
+    {
+        $this->key = $key;
+        return $this;
+    }
+
+    public function setValue(string $value): self
+    {
+        $this->value = $value;
+        return $this;
+    }
+
+    public function setPrompt(string $prompt): self
+    {
+        $this->prompt = $prompt;
+        return $this;
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    public function getPrompt(): string
+    {
+        return $this->prompt;
+    }
+
+    public function matches($value): bool
+    {
+        return (
+            \mb_strtolower($value) === \mb_strtolower($this->key)
+            || \mb_strtolower($value) === \mb_strtolower($this->value)
+        );
+    }
+}

--- a/src/Git/Manager.php
+++ b/src/Git/Manager.php
@@ -398,6 +398,53 @@ class Manager
         return $next;
     }
 
+    public function showDiff(
+        string $remote,
+        string $tag,
+        string $branch
+    ) {
+        $escaped_remote = escapeshellarg($remote);
+        $escaped_tag = escapeshellarg($tag);
+        $escaped_branch = escapeshellarg($branch);
+
+        // Fetch only the tag from the remote.
+        $fetch_tag_command = sprintf(
+            'git fetch -q %1$s refs/tags/%2$s:refs/tags/%2$s 2>&1',
+            $escaped_remote,
+            $escaped_tag
+        );
+
+        $output = array();
+        $return = 0;
+        exec($fetch_tag_command, $output, $return);
+        if ($return === 0) {
+            // Fetch only the branch from the remote.
+            $fetch_branch_command = sprintf(
+                'git fetch -q %1$s %2$s:refs/remotes/%1$s/%2$s 2>&1',
+                $escaped_remote,
+                $escaped_branch
+            );
+
+            $output = array();
+            $return = 0;
+            exec($fetch_branch_command, $output, $return);
+
+            if ($return === 0) {
+                $diff_command = sprintf(
+                    "git diff %s...%s | colordiff",
+                    $escaped_tag,
+                    $escaped_branch
+                );
+
+                \passthru($diff_command);
+            } else {
+                $this->last_error = $output;
+            }
+        } else {
+            $this->last_error = $output;
+        }
+    }
+
     /**
      * Gets the content of a file from a remote branch
      *

--- a/src/Git/Manager.php
+++ b/src/Git/Manager.php
@@ -398,11 +398,19 @@ class Manager
         return $next;
     }
 
+    /**
+     * Displays changes in the specified branch after the common ancestor of
+     * the branch and the specified tag
+     *
+     * @param string $remote the remote name.
+     * @param string $tag    the tag used on the left side of the diff.
+     * @param string $branch the branch used on the right side of the diff.
+     */
     public function showDiff(
         string $remote,
         string $tag,
         string $branch
-    ) {
+    ): void {
         $escaped_remote = escapeshellarg($remote);
         $escaped_tag = escapeshellarg($tag);
         $escaped_branch = escapeshellarg($branch);

--- a/src/Tool/Lerna.php
+++ b/src/Tool/Lerna.php
@@ -13,11 +13,13 @@ use Silverorange\PackageRelease\Console\ProcessRunner;
  */
 class Lerna
 {
-    public static function bootstrap(OutputInterface $output, Array $scopes): bool
-    {
+    public static function bootstrap(
+        OutputInterface $output,
+        array $scopes
+    ): bool {
         $command = 'lerna bootstrap';
         foreach ($scopes as $scope) {
-            $command .= sprintf(' --scope=%s', $scope);
+            $command .= sprintf(' --scope=%s', \escapeshellarg($scope));
         }
 
         return (new ProcessRunner(

--- a/src/Tool/Lerna.php
+++ b/src/Tool/Lerna.php
@@ -18,6 +18,7 @@ class Lerna
         array $scopes
     ): bool {
         $command = 'lerna bootstrap';
+
         foreach ($scopes as $scope) {
             $command .= sprintf(' --scope=%s', \escapeshellarg($scope));
         }
@@ -33,14 +34,20 @@ class Lerna
 
     public static function build(OutputInterface $output, string $scope): bool
     {
-        $command = sprintf('lerna run build --scope=%s', $scope);
+        $command = sprintf(
+            'lerna run build --scope=%s',
+            \escapeshellarg($scope)
+        );
 
         return (new ProcessRunner(
             $output,
             $command,
-            sprintf('building Lerna web package "%s"', $scope),
-            sprintf('built Lerna web package "%s"', $scope),
-            sprintf('failed to build Lerna web package "%s"', $scope)
+            sprintf('building Lerna package <variable>%s</variable>', $scope),
+            sprintf('built Lerna package <variable>%s</variable>', $scope),
+            sprintf(
+                'failed to build Lerna package <variable>%s</variable>',
+                $scope
+            )
         ))->run();
     }
 }


### PR DESCRIPTION
The intention here is to guide release managers into choosing the correct release type. You no longer need to thing about the release type before doing package-release as it will show you a diff and ask you to choose with a helpful prompt.

The old mode where you use `--type=foo` is also still supported and will skip the interactive step.

Interactive mode is also skipped if the command is run from a non-tty or if quiet mode is selected.