### PR TITLE
Add n support

### DIFF
--- a/src/Builder/BaseBuilder.php
+++ b/src/Builder/BaseBuilder.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 abstract class BaseBuilder implements BuilderInterface
 {
-    protected function hasFile($filename)
+    protected function hasFile(string $filename): bool
     {
         return (file_exists($filename) && is_readable($filename));
     }

--- a/src/Tool/Bower.php
+++ b/src/Tool/Bower.php
@@ -8,16 +8,18 @@ use Silverorange\PackageRelease\Console\ProcessRunner;
 /**
  * @package   PackageRelease
  * @author    Michael Gauthier <mike@silverorange.com>
- * @copyright 2018 silverorange
+ * @copyright 2018-2021 silverorange
  * @license   http://www.opensource.org/licenses/mit-license.html MIT License
  */
 class Bower
 {
     public static function install(OutputInterface $output): bool
     {
+        $prefix = N::getPrefix($output);
+
         return (new ProcessRunner(
             $output,
-            'bower install',
+            $prefix . 'bower install',
             'installing bower dependencies',
             'installed bower dependencies',
             'failed to install bower dependencies'

--- a/src/Tool/Ember.php
+++ b/src/Tool/Ember.php
@@ -8,16 +8,18 @@ use Silverorange\PackageRelease\Console\ProcessRunner;
 /**
  * @package   PackageRelease
  * @author    Michael Gauthier <mike@silverorange.com>
- * @copyright 2018 silverorange
+ * @copyright 2018-2021 silverorange
  * @license   http://www.opensource.org/licenses/mit-license.html MIT License
  */
 class Ember
 {
     public static function build(OutputInterface $output): bool
     {
+        $prefix = N::getPrefix($output);
+
         return (new ProcessRunner(
             $output,
-            'ember build --environment=production',
+            $prefix . 'ember build --environment=production',
             'building ember project',
             'built ember project',
             'failed to build ember project'

--- a/src/Tool/Gulp.php
+++ b/src/Tool/Gulp.php
@@ -8,16 +8,18 @@ use Silverorange\PackageRelease\Console\ProcessRunner;
 /**
  * @package   PackageRelease
  * @author    Michael Gauthier <mike@silverorange.com>
- * @copyright 2018 silverorange
+ * @copyright 2018-2021 silverorange
  * @license   http://www.opensource.org/licenses/mit-license.html MIT License
  */
 class Gulp
 {
     public static function concentrate(OutputInterface $output): bool
     {
+        $prefix = N::getPrefix($output);
+
         return (new ProcessRunner(
             $output,
-            'gulp concentrate',
+            $prefix . 'gulp concentrate',
             'building static site assets',
             'built static site assets',
             'failed to build static assets'

--- a/src/Tool/Lerna.php
+++ b/src/Tool/Lerna.php
@@ -8,7 +8,7 @@ use Silverorange\PackageRelease\Console\ProcessRunner;
 /**
  * @package   PackageRelease
  * @author    Meg Mitchell <meg@silverorange.com>
- * @copyright 2020 silverorange
+ * @copyright 2020-2021 silverorange
  * @license   http://www.opensource.org/licenses/mit-license.html MIT License
  */
 class Lerna
@@ -17,6 +17,8 @@ class Lerna
         OutputInterface $output,
         array $scopes
     ): bool {
+        $prefix = N::getPrefix($output);
+
         $command = 'lerna bootstrap';
 
         foreach ($scopes as $scope) {
@@ -25,7 +27,7 @@ class Lerna
 
         return (new ProcessRunner(
             $output,
-            $command,
+            $prefix . $command,
             'bootstrapping Lerna repository',
             'bootstrapped Lerna repository',
             'failed to bootstrap Lerna repository'
@@ -34,6 +36,8 @@ class Lerna
 
     public static function build(OutputInterface $output, string $scope): bool
     {
+        $prefix = N::getPrefix($output);
+
         $command = sprintf(
             'lerna run build --scope=%s',
             \escapeshellarg($scope)
@@ -41,7 +45,7 @@ class Lerna
 
         return (new ProcessRunner(
             $output,
-            $command,
+            $prefix . $command,
             sprintf('building Lerna package <variable>%s</variable>', $scope),
             sprintf('built Lerna package <variable>%s</variable>', $scope),
             sprintf(

--- a/src/Tool/N.php
+++ b/src/Tool/N.php
@@ -45,7 +45,7 @@ class N
     public function isAppropriate(): bool
     {
         if (self::$isAppropriate === null) {
-            if ($this->hasFile('package.json')) {
+            if (self::hasFile('package.json')) {
                 $json = json_decode(file_get_contents('package.json'), true);
                 self::$isAppropriate =  (
                     isset($json['engines']) && isset($json['engines']['node'])

--- a/src/Tool/N.php
+++ b/src/Tool/N.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Silverorange\PackageRelease\Tool;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use Silverorange\PackageRelease\Console\ProcessRunner;
+
+/**
+ * @package   PackageRelease
+ * @author    Michael Gauthier <mike@silverorange.com>
+ * @copyright 2021 silverorange
+ * @license   http://www.opensource.org/licenses/mit-license.html MIT License
+ */
+class N
+{
+    private static $isAppropriate = null;
+    private static $isDownloaded = false;
+
+    public static function download(OutputInterface $output): bool
+    {
+        if (self::isAppropriate() && !self::$isDownloaded) {
+            return (new ProcessRunner(
+                $output,
+                'n --download engine',
+                'downloading required node version',
+                'downloaded required node version',
+                'failed to download required node version'
+            ))->run();
+
+            self::$isDownloaded = true;
+        }
+    }
+
+    public static function getPrefix(OutputInterface $output): string
+    {
+        self::download($output);
+
+        if (self::isAppropriate()) {
+            return 'n exec engine ';
+        }
+
+        return '';
+    }
+
+    public function isAppropriate(): bool
+    {
+        if (self::$isAppropriate === null) {
+            if ($this->hasFile('package.json')) {
+                $json = json_decode(file_get_contents('package.json'), true);
+                self::$isAppropriate =  (
+                    isset($json['engines']) && isset($json['engines']['node'])
+                );
+            } else {
+                self::$isAppropriate = false;
+            }
+        }
+
+        return self::$isAppropriate;
+    }
+
+    protected function hasFile(string $filename): bool
+    {
+        return (file_exists($filename) && is_readable($filename));
+    }
+}

--- a/src/Tool/N.php
+++ b/src/Tool/N.php
@@ -19,18 +19,16 @@ class N
     public static function download(OutputInterface $output): bool
     {
         if (self::isAppropriate() && !self::$isDownloaded) {
-            return (new ProcessRunner(
+            self::$isDownloaded = (new ProcessRunner(
                 $output,
                 'n --download engine',
                 'downloading required node version',
                 'downloaded required node version',
                 'failed to download required node version'
             ))->run();
-
-            self::$isDownloaded = true;
         }
 
-        return true;
+        return self::$isDownloaded;
     }
 
     public static function getPrefix(OutputInterface $output): string

--- a/src/Tool/N.php
+++ b/src/Tool/N.php
@@ -47,7 +47,7 @@ class N
         if (self::$isAppropriate === null) {
             if (self::hasFile('package.json')) {
                 $json = json_decode(file_get_contents('package.json'), true);
-                self::$isAppropriate =  (
+                self::$isAppropriate = (
                     isset($json['engines']) && isset($json['engines']['node'])
                 );
             } else {

--- a/src/Tool/N.php
+++ b/src/Tool/N.php
@@ -29,6 +29,8 @@ class N
 
             self::$isDownloaded = true;
         }
+
+        return true;
     }
 
     public static function getPrefix(OutputInterface $output): string

--- a/src/Tool/Npm.php
+++ b/src/Tool/Npm.php
@@ -8,20 +8,22 @@ use Silverorange\PackageRelease\Console\ProcessRunner;
 /**
  * @package   PackageRelease
  * @author    Michael Gauthier <mike@silverorange.com>
- * @copyright 2018 silverorange
+ * @copyright 2018-2021 silverorange
  * @license   http://www.opensource.org/licenses/mit-license.html MIT License
  */
 class Npm
 {
     public static function install(OutputInterface $output): bool
     {
+        $prefix = N::getPrefix($output);
+
         $command = (static::isYarn())
             ? 'yarn install --silent'
             : 'npm install --no-package-lock --quiet';
 
         return (new ProcessRunner(
             $output,
-            $command,
+            $prefix . $command,
             'installing npm dependencies',
             'installed npm dependencies',
             'failed to install npm dependencies'
@@ -32,6 +34,8 @@ class Npm
         OutputInterface $output,
         string $flags = ''
     ): bool {
+        $prefix = N::getPrefix($output);
+
         // Note: Flags are not escaped so that multiple flags can be passed.
         $command = (static::isYarn())
             ? 'yarn build ' . $flags
@@ -39,7 +43,7 @@ class Npm
 
         return (new ProcessRunner(
             $output,
-            $command,
+            $prefix . $command,
             'building project',
             'built project',
             'failed to build project'


### PR DESCRIPTION
# Description

Add n support and use n to run node-based tools if project specifies an engine


# Testing

1. check out this PR on berna
2. run composer install

## Try preparing a PHP site 

1. go to `/so/sites/course-host/live`
2. run `/so/packages/package_release/work-myusername/bin/prepare-site --type=minor`
3. it should successfully prepare the site
4.  follow instructions to revert the release

## Try preparing a Node project
1. go to `/so/sites/emrap-fire-daemon/live`
2. run `/so/packages/package_release/work-myusername/bin/prepare-site --type=minor`
3. it should successfully prepare the site
4. follow instructions to revert the release

## Try preparing a Node project with engines specified
1. go to `/so/sites/emrap-fire-daemon/live`
2. edit `package.json` and add `"engines": { "node": "^14.0.0" },`
3. run `/so/packages/package_release/work-myusername/bin/prepare-site --type=minor`
4. it should successfully prepare the site
5. it should include a message that it downloaded an appropriate node version
6. it should only show the node download message once
7. follow instructions to revert the release