### PR TITLE
Conditionally call Bower during Ember install if the project has a bower.json file

### DIFF
--- a/src/Builder/EmberBuilder.php
+++ b/src/Builder/EmberBuilder.php
@@ -22,8 +22,10 @@ class EmberBuilder extends BaseBuilder
 
     public function build(OutputInterface $output): bool
     {
+        $hasBower = $this->hasFile('bower.json');
+
         return Npm::install($output)
-            && Bower::install($output)
+            && ($hasBower || Bower::install($output))
             && Ember::build($output);
     }
 


### PR DESCRIPTION
New Ember projects do not use Bower